### PR TITLE
[Fix] 소셜로그인 시 회원가입/로그인 구분

### DIFF
--- a/src/components/common/auth/ui/SocialLogin.tsx
+++ b/src/components/common/auth/ui/SocialLogin.tsx
@@ -18,8 +18,8 @@ const SocialLogin = ({ type }: SocialLoginProps) => {
         : ''
     }`;
 
-    console.log('SearchParam: ', searchParams);
-    console.log(redirectPath);
+    // console.log('SearchParam: ', searchParams);
+    // console.log(redirectPath);
     const basePath = process.env.REACT_APP_API_BASE_PATH || "https://letscareer-test.shop"
     const path = `${basePath}/oauth2/authorize/${
       socialType === 'KAKAO' ? 'kakao' : 'naver'

--- a/src/components/common/mypage/privacy/section/BasicInfo.tsx
+++ b/src/components/common/mypage/privacy/section/BasicInfo.tsx
@@ -91,6 +91,7 @@ const BasicInfo = () => {
 
   useEffect(() => {
     setIsSameEmail(user.email === user.contactEmail);
+    // console.log(user);
   }, [user]);
 
   return (
@@ -237,7 +238,7 @@ const BasicInfo = () => {
         </div>
       </div>
       <Button onClick={handleSubmit}>{
-        (user.contactEmail === '' && user.university === '' && user.grade === '' && user.major === '' && user.wishJob === '' && user.wishCompany === '') ? 
+        !(user.contactEmail || user.university || user.grade || user.major || user.wishJob || user.wishCompany) ? 
           '기본 정보 등록하기'
          : 
           '기본 정보 수정하기'

--- a/src/pages/common/auth/Login.tsx
+++ b/src/pages/common/auth/Login.tsx
@@ -106,6 +106,12 @@ const Login = () => {
   }, [searchParams, setSearchParams]);
 
   const handleLoginSuccess = (token: any) => {
+    // console.log('LOGIN ISNEW: ', token.isNew);
+
+    if (token.isNew) {
+      navigate(`/signup?result=${JSON.stringify(token)}&redirect=${searchParams.get('redirect')}`);
+      return;
+    }
     login(
       token.accessToken,
       token.refreshToken,

--- a/src/pages/common/auth/SignUp.tsx
+++ b/src/pages/common/auth/SignUp.tsx
@@ -21,7 +21,7 @@ import useAuthStore from '../../../store/useAuthStore';
 import { ErrorResonse } from '../../../interfaces/interface';
 
 const SignUp = () => {
-  const { isLoggedIn } = useAuthStore();
+  const { isLoggedIn, login } = useAuthStore();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [isSocial, setIsSocial] = useState<boolean>(false);
@@ -35,9 +35,14 @@ const SignUp = () => {
       return undefined;
     }
     const token = JSON.parse(result);
+    // console.log('SIGNUP ISNEW: ', token.isNew);
     localStorage.setItem('access-token', token.accessToken);
     localStorage.setItem('refresh-token', token.refreshToken);
-    // axios.defaults.headers.common.Authorization = `Bearer ${token.accessToken}`;
+    if (!token.isNew) {
+      const redirect = searchParams.get('redirect') || '/';
+      login(token.accessToken, token.refreshToken, redirect);
+      return;
+    }
     setIsSocial(true);
 
     return token;


### PR DESCRIPTION
> Close #713 

- 로그인 화면에서 소셜로그인 클릭 시 처음 가입하는 것임에도 추가정보입력 받지 않는 이슈 해결
- 회원가입 화면에서 소셜로그인 클릭 시 로그인일 경우 추가정보 입력 받지 않도록 수정
- 마이페이지의 추가정보입력 수정에 대해, 등록/수정 구분이 안 되고 있던 이슈 해결
