### PR TITLE
[Fix] 블로그 게시 로직 수정

### DIFF
--- a/src/components/admin/blog/BlogTable.tsx
+++ b/src/components/admin/blog/BlogTable.tsx
@@ -54,7 +54,9 @@ export default function BlogTable() {
       const reqBody: PatchBlogReqBody = {
         id: checkedBlog.id,
         isDisplayed: true,
-        displayDate: dayjs().format('YYYY-MM-DDTHH:mm'),
+        displayDate: checkedBlog.displayDate
+          ? checkedBlog.displayDate.format('YYYY-MM-DDTHH:mm')
+          : dayjs().format('YYYY-MM-DDTHH:mm'),
       };
       patchBlogMutation.mutate(reqBody);
     } else {

--- a/src/pages/admin/BlogEditPage.tsx
+++ b/src/pages/admin/BlogEditPage.tsx
@@ -132,8 +132,10 @@ const BlogEditPage = () => {
       tagList: editingValue.tagList.map((tag) => tag.id),
       displayDate:
         name === 'publish'
-          ? dayjs().format('YYYY-MM-DDTHH:mm')
-          : dateTime?.format('YYYY-MM-DDTHH:mm') || '',
+          ? dateTime
+            ? dateTime?.format('YYYY-MM-DDTHH:mm')
+            : dayjs().format('YYYY-MM-DDTHH:mm')
+          : (dateTime?.format('YYYY-MM-DDTHH:mm') ?? ''),
     });
 
     setSnackbar('블로그가 수정되었습니다.');


### PR DESCRIPTION
게시 일자가 있으면 그대로, 없으면 현재 날짜로 설정

## 연관 작업

- [LC-1079]



[LC-1079]: https://letscareer-team.atlassian.net/browse/LC-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ