### PR TITLE
LC-2173 USER-NEW-챌린지-대시보드-모바일-안보이게-하는-코드-삭제

### DIFF
--- a/src/components/common/challenge/DashboardLayout.tsx
+++ b/src/components/common/challenge/DashboardLayout.tsx
@@ -89,26 +89,10 @@ const DashboardLayout = () => {
 
   return (
     <div className="min-h-[calc(100vh-4rem)] sm:min-h-[calc(100vh-6rem)]">
-      <div className="flex h-[calc(100vh-4rem)] flex-col items-center justify-center sm:h-[calc(100vh-6rem)] lg:hidden">
-        <div className="-mt-24">
-          <h1 className="text-neutral-black text-center text-2xl font-semibold">
-            챌린지 페이지는
-            <br />
-            데스크탑에서만 이용 가능합니다!
-          </h1>
-          <p className="mt-2 text-center">
-            데스크탑으로 접속해주시거나
-            <br />
-            화면의 크기를 좌우로 늘려주세요!
-          </p>
-        </div>
-      </div>
-      <div className="hidden px-6 py-6 lg:block">
-        <div className="mx-auto flex w-[1024px]">
-          <DashboardNavBar />
-          <div className="min-w-0 flex-1">
-            <Outlet />
-          </div>
+      <div className="mx-auto flex w-[1024px]">
+        <DashboardNavBar />
+        <div className="min-w-0 flex-1">
+          <Outlet />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 연관 작업

- [LC-2173]

[LC-2173]:https://letscareer-team.atlassian.net/browse/LC-2173?atlOrigin=eyJpIjoiMTRmZWU5MTZmMTQ3NDg4YTliNTVkZTdhNzY1ODI4YzIiLCJwIjoiaiJ9

[LC-2173]: https://letscareer-team.atlassian.net/browse/LC-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2173]: https://letscareer-team.atlassian.net/browse/LC-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ