### PR TITLE
LC-2975 대시보드 입장 버튼 비활 범위 수정

### DIFF
--- a/src/domain/mypage/application/utils/applicationCardConfig.ts
+++ b/src/domain/mypage/application/utils/applicationCardConfig.ts
@@ -1,5 +1,6 @@
 import { MypageApplication } from '@/api/application';
 import { getReportThumbnail } from '@/domain/mypage/credit/CreditListItem';
+import dayjs from '@/lib/dayjs';
 import {
   challengePricePlanToText,
   newProgramTypeToText,
@@ -95,13 +96,14 @@ const toProgramCardConfig = (
       ? getReportThumbnail(reportType)
       : (programThumbnail ?? '');
 
-  const isDashboardDisabled = programStatusType !== 'PROCEEDING';
+  const isChallengeDashboardVisible =
+    pricePlanType !== 'LIGHT' && programStartDate?.isBefore(dayjs());
+  const isDashboardVisible = isChallenge ? isChallengeDashboardVisible : isLive;
 
   const actionButton =
-    (isChallenge || isLive) && programType && programId != null && id != null
+    isDashboardVisible && programType && programId != null && id != null
       ? {
           label: isChallenge ? '대시보드 입장' : '클래스 입장',
-          disabled: isDashboardDisabled,
           href: isChallenge
             ? `/challenge/${id}/${programId}`
             : `/program/live/${programId}`,


### PR DESCRIPTION
- 시작일 전, light 플랜일 시 비노출
- 시작일 후 모두 노출

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-2975]

[LC-2975]:https://letscareer-team.atlassian.net/browse/LC-2975


[LC-2975]: https://letscareer-team.atlassian.net/browse/LC-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-2975]: https://letscareer-team.atlassian.net/browse/LC-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ