### PR TITLE
LC-3000 npm pnpm 전환

### DIFF
--- a/.claude/docs/letscareer/pnpm전환 메모 폴더/04-vercel-deployment.md
+++ b/.claude/docs/letscareer/pnpm전환 메모 폴더/04-vercel-deployment.md
@@ -122,10 +122,10 @@ Vercel이 다음 중 하나라도 해당하면 빌드를 트리거한다:
 자동 기능은 워크스페이스 *외부* 변경(루트 `*.md`, `.claude/**`, `.github/**` 등)을 의존 그래프 외부로 간주해 모든 앱을 트리거할 수 있다. 이를 컷하기 위해 [scripts/vercel-skip-build.sh](../../../../scripts/vercel-skip-build.sh)를 **Settings → Git → Ignored Build Step**에 등록해 결합 사용한다.
 
 ```bash
-bash scripts/vercel-skip-build.sh
+bash "$(git rev-parse --show-toplevel)/scripts/vercel-skip-build.sh"
 ```
 
-3개 프로젝트 모두 동일 명령. 두 필터는 **AND** 관계 — 둘 중 하나라도 "스킵"이면 빌드 안 함. 역할 분담:
+3개 프로젝트 모두 동일 명령. IBS의 cwd가 `apps/<name>/`이므로 상대 경로 `bash scripts/...`는 exit 127로 실패한다 — 반드시 `$(git rev-parse --show-toplevel)` 로 절대 경로 변환. 두 필터는 **AND** 관계 — 둘 중 하나라도 "스킵"이면 빌드 안 함. 역할 분담:
 
 - *Custom IBS* → 루트 `*.md` 및 dev 도구 폴더 (`.claude`, `.cursor`, `.gemini`, `.github`, `.vscode`) 컷
 - *Skip Unaffected* → 워크스페이스 내부 의존성 정밀 컷

--- a/.claude/docs/letscareer/pnpm전환 메모 폴더/07-build-filter.md
+++ b/.claude/docs/letscareer/pnpm전환 메모 폴더/07-build-filter.md
@@ -29,10 +29,12 @@
 ### 2️⃣ Ignored Build Step → "Run my own command"
 
 ```bash
-bash scripts/vercel-skip-build.sh
+bash "$(git rev-parse --show-toplevel)/scripts/vercel-skip-build.sh"
 ```
 
-세 프로젝트 모두 같은 명령. 앱별 분기 불필요 — 워크스페이스 내부 컷은 auto가 처리한다. 스크립트는 git 루트로 `cd`하므로 Vercel의 cwd와 무관하게 동작.
+세 프로젝트 모두 같은 명령. 앱별 분기 불필요 — 워크스페이스 내부 컷은 auto가 처리한다.
+
+> ⚠️ **`bash scripts/vercel-skip-build.sh` 상대 경로는 사용 금지** — Vercel IBS의 cwd는 프로젝트 Root Directory(`apps/<name>/`)이지 repo 루트가 아니라서 `bash: scripts/vercel-skip-build.sh: No such file or directory` (exit 127)로 실패한다. `$(git rev-parse --show-toplevel)`로 repo 루트 절대 경로를 동적 탐지하면 cwd와 무관하게 동작한다.
 
 ## 스크립트 — `scripts/vercel-skip-build.sh`
 

--- a/scripts/vercel-skip-build.sh
+++ b/scripts/vercel-skip-build.sh
@@ -14,7 +14,11 @@
 #
 # Vercel UI 적용 (web/admin/mentor 3개 프로젝트 각각):
 #   Settings → Git → Ignored Build Step → "Run my own command"
-#     bash scripts/vercel-skip-build.sh
+#     bash "$(git rev-parse --show-toplevel)/scripts/vercel-skip-build.sh"
+#
+# 주의: `bash scripts/vercel-skip-build.sh` (상대 경로) 는 IBS의 cwd가
+# 프로젝트 Root Directory(`apps/<name>/`)이라 파일을 못 찾는다 (exit 127).
+# `$(git rev-parse --show-toplevel)` 로 repo 루트 절대 경로를 동적 탐지.
 #
 # 상세 설계·함정·검증 방법:
 #   .claude/docs/letscareer/pnpm전환 메모 폴더/07-build-filter.md


### PR DESCRIPTION
Vercel Ignored Build Step 의 cwd 가 프로젝트 Root Directory(`apps/<name>/`) 이라 `bash scripts/vercel-skip-build.sh` 상대 경로는 exit 127 로 실패한다. `bash "$(git rev-parse --show-toplevel)/scripts/vercel-skip-build.sh"` 로 변경해 cwd 와 무관하게 repo 루트의 스크립트를 찾도록 한다.

스크립트 자체 로직 변경 없음 — 헤더 주석과 04, 07 문서의 명령 예시만 수정.

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3000]

[LC-3000]:https://letscareer-team.atlassian.net/browse/LC-3000


[LC-3000]: https://letscareer-team.atlassian.net/browse/LC-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3000]: https://letscareer-team.atlassian.net/browse/LC-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ