### PR TITLE
chore(engines): pnpm 요구를 >=10 → >=9 로 완화

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=18.17",
-    "pnpm": ">=10"
+    "pnpm": ">=9"
   },
   "scripts": {
     "dev": "turbo run dev",


### PR DESCRIPTION
Vercel 시스템 pnpm 9.15.9 가 engines.pnpm '>=10' 으로 install 거부. corepack prepare 후에도 PATH 우선순위로 corepack shim 무력화되어 시스템 pnpm 이 잡히는 함정.

lockfileVersion 9.0 은 pnpm 9/10 양쪽 모두 호환되므로 engines 만 완화. packageManager 'pnpm@10.33.0' 필드는 유지하여 로컬 dev 환경의
pnpm 10 사용은 그대로 강제됨.

추후 Vercel 측에서 pnpm 10 정복 (PATH 또는 ENABLE_EXPERIMENTAL_COREPACK) 정착되면 다시 '>=10' 으로 환원 권장.

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->
