### PR TITLE
LC-3017 ADMIN 챌린지 운영 제출확인 제출 리스트 깨짐 이슈

### DIFF
--- a/apps/mentor/vercel.json
+++ b/apps/mentor/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
apps/mentor 에 vercel.json 이 없어 Vite SPA 의 클라이언트 라우트(/challenges/123, /profile, /notice/123 등) 직링크가 모두 Vercel 정적 파일 lookup → 404 (NOT_FOUND) 로 떨어지던 문제. apps/admin 과 동일한 catch-all 리라이트 추가:

  /(.*) → /index.html

이로써 mentor 서브도메인의 어떤 경로든 SPA index.html 이 먼저 서빙되고
react-router-dom 이 클라이언트에서 라우팅을 처리한다.

이 누락이 지금 드러난 계기: mypage FeedbackCard 가 buildCrossAppUrl 로 mentor 서브도메인의 /challenges/{id} 로 직접 점프하는 첫 케이스가 추가되면서.

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3017]

[LC-3017]:https://letscareer-team.atlassian.net/browse/LC-3017


[LC-3017]: https://letscareer-team.atlassian.net/browse/LC-3017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3017]: https://letscareer-team.atlassian.net/browse/LC-3017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ