### PR TITLE
LC-3026 추상화 작업 4

### DIFF
--- a/apps/web/src/api/application.ts
+++ b/apps/web/src/api/application.ts
@@ -338,18 +338,20 @@ export type MypageApplication = z.infer<
 
 export const useMypageApplicationsQueryKey = 'useMypageApplicationsQueryKey';
 
+export const mypageApplicationsQueryOptions = {
+  queryKey: [useMypageApplicationsQueryKey] as const,
+  queryFn: async () => {
+    const res = await axiosV2.get('/user/applications');
+    return mypageApplicationsSchema
+      .parse(res.data.data)
+      .applicationList.filter(
+        (application) => application.programType !== 'REPORT',
+      );
+  },
+};
+
 export const useMypageApplicationsQuery = () => {
-  return useQuery({
-    queryKey: [useMypageApplicationsQueryKey],
-    queryFn: async () => {
-      const res = await axiosV2.get('/user/applications');
-      return mypageApplicationsSchema
-        .parse(res.data.data)
-        .applicationList.filter(
-          (application) => application.programType !== 'REPORT',
-        );
-    },
-  });
+  return useQuery(mypageApplicationsQueryOptions);
 };
 
 const participationInfoSchema = z.object({

--- a/apps/web/src/api/career/career.ts
+++ b/apps/web/src/api/career/career.ts
@@ -11,31 +11,36 @@ import { z } from 'zod';
 
 export const UserCareerQueryKey = 'userCareerQueryKey';
 
+export const userCareerQueryOptions = (
+  pageable: Pageable,
+  sortable?: Sortable,
+) => ({
+  queryKey: [
+    UserCareerQueryKey,
+    ...Object.values(pageable),
+    ...(sortable ? Object.values(sortable) : []),
+  ] as const,
+  queryFn: async () => {
+    const params = new URLSearchParams({
+      page: String(pageable.page),
+      size: String(pageable.size),
+    });
+
+    if (sortable) {
+      params.append('sort', String(sortable.sort));
+      params.append('sortType', String(sortable.sortType));
+    }
+
+    const res = await axios.get(`/user-career/my?${params.toString()}`);
+    return userCareerListSchema.parse(res.data.data);
+  },
+});
+
 export const useGetUserCareerQuery = (
   pageable: Pageable,
   sortable?: Sortable,
 ) => {
-  return useQuery({
-    queryKey: [
-      UserCareerQueryKey,
-      ...Object.values(pageable),
-      ...(sortable ? Object.values(sortable) : []),
-    ],
-    queryFn: async () => {
-      const params = new URLSearchParams({
-        page: String(pageable.page),
-        size: String(pageable.size),
-      });
-
-      if (sortable) {
-        params.append('sort', String(sortable.sort));
-        params.append('sortType', String(sortable.sortType));
-      }
-
-      const res = await axios.get(`/user-career/my?${params.toString()}`);
-      return userCareerListSchema.parse(res.data.data);
-    },
-  });
+  return useQuery(userCareerQueryOptions(pageable, sortable));
 };
 
 export const usePostUserCareerMutation = () => {

--- a/apps/web/src/api/experience/experience.ts
+++ b/apps/web/src/api/experience/experience.ts
@@ -22,6 +22,21 @@ export const useGetUserExperienceFiltersQuery = () => {
   });
 };
 
+export const allUserExperienceQueryOptions = (
+  filter: ExperienceFiltersReq,
+  sortable: Sortable,
+  pageable: Pageable,
+) => ({
+  queryKey: [UserExperienceQueryKey, filter, sortable, pageable] as const,
+  queryFn: async () => {
+    const res = await axios.post(
+      `/user-experience/search?page=${pageable.page}&size=${pageable.size}`,
+      { ...filter, sortType: sortable },
+    );
+    return userExperienceListSchema.parse(res.data.data);
+  },
+});
+
 export const useGetAllUserExperienceQuery = (
   filter: ExperienceFiltersReq,
   sortable: Sortable,
@@ -29,14 +44,7 @@ export const useGetAllUserExperienceQuery = (
   options?: { enabled?: boolean },
 ) => {
   return useQuery({
-    queryKey: [UserExperienceQueryKey, filter, sortable, pageable],
-    queryFn: async () => {
-      const res = await axios.post(
-        `/user-experience/search?page=${pageable.page}&size=${pageable.size}`,
-        { ...filter, sortType: sortable },
-      );
-      return userExperienceListSchema.parse(res.data.data);
-    },
+    ...allUserExperienceQueryOptions(filter, sortable, pageable),
     enabled: options?.enabled,
   });
 };

--- a/apps/web/src/api/magnet/magnet.ts
+++ b/apps/web/src/api/magnet/magnet.ts
@@ -392,6 +392,16 @@ export const usePostMagnetApplicationMutation = () => {
 };
 
 // 마이페이지 MY 마그넷 신청현황 조회
+export const mypageMagnetListQueryOptions = (typeList?: MagnetType[]) => ({
+  queryKey: [mypageMagnetListQueryKey, typeList] as const,
+  queryFn: async (): Promise<MypageMagnetListResponse> => {
+    const res = await axios.get('/magnet/mypage', {
+      params: { typeList },
+    });
+    return mypageMagnetListResponseSchema.parse(res.data.data);
+  },
+});
+
 export const useGetMypageMagnetListQuery = ({
   typeList,
   enabled,
@@ -400,13 +410,7 @@ export const useGetMypageMagnetListQuery = ({
   enabled?: boolean;
 }) => {
   return useQuery({
-    queryKey: [mypageMagnetListQueryKey, typeList],
-    queryFn: async (): Promise<MypageMagnetListResponse> => {
-      const res = await axios.get('/magnet/mypage', {
-        params: { typeList },
-      });
-      return mypageMagnetListResponseSchema.parse(res.data.data);
-    },
+    ...mypageMagnetListQueryOptions(typeList),
     enabled,
   });
 };

--- a/apps/web/src/api/user/user.ts
+++ b/apps/web/src/api/user/user.ts
@@ -258,8 +258,8 @@ export const useUserQuery = ({
   ...options
 }: { enabled?: boolean; retry?: boolean | number } = {}) => {
   return useQuery({
-    ...options,
     ...userQueryOptions,
+    ...options,
   });
 };
 

--- a/apps/web/src/api/user/user.ts
+++ b/apps/web/src/api/user/user.ts
@@ -245,17 +245,21 @@ export type User = z.infer<typeof userSchema>;
 /** GET /api/v1/user */
 export const useUserQueryKey = 'useUserQueryKey';
 
+export const userQueryOptions = {
+  queryKey: [useUserQueryKey] as const,
+  queryFn: async () => {
+    const res = await axios.get(`/user`);
+    return userSchema.parse(res.data.data);
+  },
+  refetchOnWindowFocus: false,
+};
+
 export const useUserQuery = ({
   ...options
 }: { enabled?: boolean; retry?: boolean | number } = {}) => {
   return useQuery({
     ...options,
-    queryKey: [useUserQueryKey],
-    queryFn: async () => {
-      const res = await axios.get(`/user`);
-      return userSchema.parse(res.data.data);
-    },
-    refetchOnWindowFocus: false,
+    ...userQueryOptions,
   });
 };
 
@@ -399,14 +403,17 @@ export const useIsAdminQuery = ({
 
 /** GET [유저] 서류(자소서, 포트폴리오 등) 조회 /api/v1/user-document */
 export const UseGetUserDocumentListQueryKey = 'useGetUserDocumentListQueryKey';
+
+export const userDocumentListQueryOptions = {
+  queryKey: [UseGetUserDocumentListQueryKey] as const,
+  queryFn: async () => {
+    const res = await axios.get('/user-document');
+    return userDocumentListSchema.parse(res.data.data);
+  },
+};
+
 export const useGetUserDocumentListQuery = () => {
-  return useQuery({
-    queryKey: [UseGetUserDocumentListQueryKey],
-    queryFn: async () => {
-      const res = await axios.get('/user-document');
-      return userDocumentListSchema.parse(res.data.data);
-    },
-  });
+  return useQuery(userDocumentListQueryOptions);
 };
 
 /** DELETE [유저] 서류(자소서, 포트폴리오 등) 삭제 /api/v1/user-document/{userDocumentId}*/

--- a/apps/web/src/app/(user)/mypage/career/board/page.tsx
+++ b/apps/web/src/app/(user)/mypage/career/board/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import CareerBoard from '@/domain/career-board';
 import { CareerDataStatusProvider } from '@/domain/career-board/contexts/CareerDataStatusContext';
+import dynamic from 'next/dynamic';
+
+const CareerBoard = dynamic(() => import('@/domain/career-board'), {
+  ssr: false,
+});
 
 export default function Page() {
   return (

--- a/apps/web/src/domain/career-board/sections/CareerGrowthSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerGrowthSection.tsx
@@ -1,11 +1,15 @@
-import { useMypageApplicationsQuery } from '@/api/application';
-import { useGetMypageMagnetListQuery } from '@/api/magnet/magnet';
+'use client';
+
+import { mypageApplicationsQueryOptions } from '@/api/application';
+import { mypageMagnetListQueryOptions } from '@/api/magnet/magnet';
+import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
 import LoadingContainer from '@/common/loading/LoadingContainer';
 import {
   APPLICATION_CATEGORY_OPTIONS,
   ApplicationCategory,
 } from '@/domain/mypage/application/constants';
 import CategoryChips from '@/domain/mypage/ui/button/CategoryChips';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
@@ -16,6 +20,9 @@ import {
   toCareerGrowthCardConfigs,
   toLibraryCardConfigs,
 } from '../utils/careerGrowthCard';
+
+const TITLE = '커리어 성장';
+const HREF = '/mypage/application';
 
 const EMPTY_CONFIG_BY_CATEGORY: Record<
   ApplicationCategory,
@@ -45,20 +52,42 @@ const EMPTY_CONFIG_BY_CATEGORY: Record<
 
 const CareerGrowthSection = () => {
   const router = useRouter();
-  const {
-    data: applications,
-    isLoading,
-    isError,
-  } = useMypageApplicationsQuery();
+
+  return (
+    <AsyncBoundary
+      pendingFallback={
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={
+            <LoadingContainer text="진행중인 프로그램을 불러오는 중입니다." />
+          }
+        />
+      }
+      rejectedFallback={({ resetErrorBoundary }) => (
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<SectionErrorFallback onRetry={resetErrorBoundary} />}
+        />
+      )}
+    >
+      <CareerGrowthContent />
+    </AsyncBoundary>
+  );
+};
+
+export default CareerGrowthSection;
+
+const CareerGrowthContent = () => {
+  const router = useRouter();
+  const { data: applications } = useSuspenseQuery(
+    mypageApplicationsQueryOptions,
+  );
   const { setHasCareerData } = useCareerDataStatus();
   const [category, setCategory] = useState<ApplicationCategory>('PROGRAM');
 
   const isLibraryTab = category === 'LIBRARY';
-
-  const { data: magnetData, isLoading: isMagnetLoading } =
-    useGetMypageMagnetListQuery({
-      enabled: isLibraryTab,
-    });
 
   const items = useMemo(
     () => toCareerGrowthItems(applications ?? []),
@@ -82,16 +111,12 @@ const CareerGrowthSection = () => {
     );
   }, [category, items]);
 
-  const cardConfigs = useMemo(() => {
-    if (isLibraryTab) {
-      return toLibraryCardConfigs(magnetData?.magnetList ?? []);
-    }
-    return toCareerGrowthCardConfigs(visibleItems, category);
-  }, [isLibraryTab, magnetData, visibleItems, category]);
+  const programCardConfigs = useMemo(
+    () => toCareerGrowthCardConfigs(visibleItems, category),
+    [visibleItems, category],
+  );
 
-  // 데이터 존재 여부 확인 (전체 프로그램 기준)
   const hasData = items.length > 0;
-  const hasVisibleData = cardConfigs.length > 0;
 
   useEffect(() => {
     if (hasData) {
@@ -99,35 +124,10 @@ const CareerGrowthSection = () => {
     }
   }, [hasData, setHasCareerData]);
 
-  if (isLoading || (isLibraryTab && isMagnetLoading)) {
-    return (
-      <CareerCard
-        title="커리어 성장"
-        labelOnClick={() => router.push('/mypage/application')}
-        body={
-          <LoadingContainer text="진행중인 프로그램을 불러오는 중입니다." />
-        }
-      />
-    );
-  }
-
-  if (isError) {
-    return (
-      <CareerCard
-        title="커리어 성장"
-        labelOnClick={() => router.push('/mypage/application')}
-        body={
-          <div className="text-neutral-40 py-8 text-center">
-            데이터를 불러오는 중 오류가 발생했습니다.
-          </div>
-        }
-      />
-    );
-  }
   return (
     <CareerCard
-      title="커리어 성장"
-      labelOnClick={() => router.push('/mypage/application')}
+      title={TITLE}
+      labelOnClick={() => router.push(HREF)}
       body={
         <div className="flex flex-col gap-6 pt-1">
           <CategoryChips
@@ -135,8 +135,19 @@ const CareerGrowthSection = () => {
             selected={category}
             onChange={setCategory}
           />
-          {hasVisibleData ? (
-            <CareerGrowthList items={cardConfigs} />
+          {isLibraryTab ? (
+            <AsyncBoundary
+              pendingFallback={
+                <LoadingContainer text="자료집을 불러오는 중입니다." />
+              }
+              rejectedFallback={({ resetErrorBoundary }) => (
+                <SectionErrorFallback onRetry={resetErrorBoundary} />
+              )}
+            >
+              <LibraryGrowthList />
+            </AsyncBoundary>
+          ) : programCardConfigs.length > 0 ? (
+            <CareerGrowthList items={programCardConfigs} />
           ) : (
             <div className="pb-6">
               <CareerCard.Empty
@@ -155,4 +166,40 @@ const CareerGrowthSection = () => {
   );
 };
 
-export default CareerGrowthSection;
+const LibraryGrowthList = () => {
+  const router = useRouter();
+  const { data: magnetData } = useSuspenseQuery(mypageMagnetListQueryOptions());
+
+  const cardConfigs = useMemo(
+    () => toLibraryCardConfigs(magnetData?.magnetList ?? []),
+    [magnetData],
+  );
+
+  if (cardConfigs.length === 0) {
+    return (
+      <div className="pb-6">
+        <CareerCard.Empty
+          description={EMPTY_CONFIG_BY_CATEGORY.LIBRARY.description}
+          buttonText={EMPTY_CONFIG_BY_CATEGORY.LIBRARY.buttonText}
+          buttonHref={EMPTY_CONFIG_BY_CATEGORY.LIBRARY.href}
+          onClick={() => router.push(EMPTY_CONFIG_BY_CATEGORY.LIBRARY.href)}
+        />
+      </div>
+    );
+  }
+
+  return <CareerGrowthList items={cardConfigs} />;
+};
+
+const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);

--- a/apps/web/src/domain/career-board/sections/CareerGrowthSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerGrowthSection.tsx
@@ -15,6 +15,7 @@ import { useEffect, useMemo, useState } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
 import CareerGrowthList from '../ui/CareerGrowthList';
+import { SectionErrorFallback } from '../ui/SectionErrorFallback';
 import { toCareerGrowthItems } from '../utils/careerGrowth';
 import {
   toCareerGrowthCardConfigs,
@@ -190,16 +191,3 @@ const LibraryGrowthList = () => {
 
   return <CareerGrowthList items={cardConfigs} />;
 };
-
-const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-8">
-    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
-    <button
-      type="button"
-      onClick={onRetry}
-      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
-    >
-      다시 시도
-    </button>
-  </div>
-);

--- a/apps/web/src/domain/career-board/sections/CareerPlanSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerPlanSection.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
+import { SectionErrorFallback } from '../ui/SectionErrorFallback';
 
 const TITLE = '커리어 계획';
 const HREF = '/mypage/career/plan';
@@ -85,19 +86,6 @@ const CareerPlanContent = () => {
     />
   );
 };
-
-const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-8">
-    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
-    <button
-      type="button"
-      onClick={onRetry}
-      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
-    >
-      다시 시도
-    </button>
-  </div>
-);
 
 interface CareerPlanBodyProps {
   wishField: string | null;

--- a/apps/web/src/domain/career-board/sections/CareerPlanSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerPlanSection.tsx
@@ -1,22 +1,54 @@
-import { useUserQuery } from '@/api/user/user';
+'use client';
+
+import { userQueryOptions } from '@/api/user/user';
+import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
 import LoadingContainer from '@/common/loading/LoadingContainer';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
 
+const TITLE = '커리어 계획';
+const HREF = '/mypage/career/plan';
+
 const CareerPlanSection = () => {
   const router = useRouter();
-  const { data: userData, isLoading } = useUserQuery();
+
+  return (
+    <AsyncBoundary
+      pendingFallback={
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<LoadingContainer text="커리어 계획 조회 중" />}
+        />
+      }
+      rejectedFallback={({ resetErrorBoundary }) => (
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<SectionErrorFallback onRetry={resetErrorBoundary} />}
+        />
+      )}
+    >
+      <CareerPlanContent />
+    </AsyncBoundary>
+  );
+};
+
+export default CareerPlanSection;
+
+const CareerPlanContent = () => {
+  const router = useRouter();
+  const { data: userData } = useSuspenseQuery(userQueryOptions);
   const { setHasCareerData } = useCareerDataStatus();
 
-  // 서버에서 받아온 데이터
   const wishField = userData?.wishField ?? null;
   const wishJob = userData?.wishJob ?? null;
   const wishIndustry = userData?.wishIndustry ?? null;
   const wishCompany = userData?.wishCompany ?? null;
 
-  // 데이터 존재 여부 확인 (null, 빈 문자열 체크)
   const hasData =
     (wishField && wishField.trim()) ||
     (wishJob && wishJob.trim()) ||
@@ -29,20 +61,10 @@ const CareerPlanSection = () => {
     }
   }, [hasData, setHasCareerData]);
 
-  if (isLoading) {
-    return (
-      <CareerCard
-        title="커리어 계획"
-        labelOnClick={() => router.push('/mypage/career/plan')}
-        body={<LoadingContainer text="커리어 계획 조회 중" />}
-      />
-    );
-  }
-
   return (
     <CareerCard
-      title="커리어 계획"
-      labelOnClick={() => router.push('/mypage/career/plan')}
+      title={TITLE}
+      labelOnClick={() => router.push(HREF)}
       body={
         hasData ? (
           <CareerPlanBody
@@ -55,8 +77,8 @@ const CareerPlanSection = () => {
           <CareerCard.Empty
             description="아직 커리어 방향을 설정하지 않았어요."
             buttonText="커리어 계획하기"
-            buttonHref="/mypage/career/plan"
-            onClick={() => router.push('/mypage/career/plan')}
+            buttonHref={HREF}
+            onClick={() => router.push(HREF)}
           />
         )
       }
@@ -64,7 +86,18 @@ const CareerPlanSection = () => {
   );
 };
 
-export default CareerPlanSection;
+const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);
 
 interface CareerPlanBodyProps {
   wishField: string | null;
@@ -79,7 +112,6 @@ const CareerPlanBody = ({
   wishIndustry,
   wishCompany,
 }: CareerPlanBodyProps) => {
-  // 희망 직군/직무 조합
   const jobRoleText = (() => {
     const parts: string[] = [];
     if (wishField && wishField.trim()) parts.push(wishField.trim());

--- a/apps/web/src/domain/career-board/sections/CareerRecordSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerRecordSection.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
+import { SectionErrorFallback } from '../ui/SectionErrorFallback';
 
 const TITLE = '커리어 기록';
 const HREF = '/mypage/career/record';
@@ -92,19 +93,6 @@ const CareerRecordContent = () => {
     />
   );
 };
-
-const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-8">
-    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
-    <button
-      type="button"
-      onClick={onRetry}
-      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
-    >
-      다시 시도
-    </button>
-  </div>
-);
 
 interface CareerRecordBodyProps {
   category: string;

--- a/apps/web/src/domain/career-board/sections/CareerRecordSection.tsx
+++ b/apps/web/src/domain/career-board/sections/CareerRecordSection.tsx
@@ -1,17 +1,52 @@
-import { useGetUserCareerQuery } from '@/api/career/career';
+'use client';
+
+import { userCareerQueryOptions } from '@/api/career/career';
+import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
 import LoadingContainer from '@/common/loading/LoadingContainer';
 import { toCareerDateDot } from '@/utils/career';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
 
+const TITLE = '커리어 기록';
+const HREF = '/mypage/career/record';
+
 const CareerRecordSection = () => {
   const router = useRouter();
 
-  const { data, isLoading } = useGetUserCareerQuery(
-    { page: 0, size: 1 },
-    { sort: 'desc', sortType: 'START_DATE' },
+  return (
+    <AsyncBoundary
+      pendingFallback={
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<LoadingContainer text="커리어 기록 조회 중" />}
+        />
+      }
+      rejectedFallback={({ resetErrorBoundary }) => (
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<SectionErrorFallback onRetry={resetErrorBoundary} />}
+        />
+      )}
+    >
+      <CareerRecordContent />
+    </AsyncBoundary>
+  );
+};
+
+export default CareerRecordSection;
+
+const CareerRecordContent = () => {
+  const router = useRouter();
+  const { data } = useSuspenseQuery(
+    userCareerQueryOptions(
+      { page: 0, size: 1 },
+      { sort: 'desc', sortType: 'START_DATE' },
+    ),
   );
   const { setHasCareerData } = useCareerDataStatus();
 
@@ -24,20 +59,10 @@ const CareerRecordSection = () => {
     }
   }, [hasData, setHasCareerData]);
 
-  if (isLoading) {
-    return (
-      <CareerCard
-        title="커리어 기록"
-        labelOnClick={() => router.push('/mypage/career/record')}
-        body={<LoadingContainer text="커리어 기록 조회 중" />}
-      />
-    );
-  }
-
   return (
     <CareerCard
-      title="커리어 기록"
-      labelOnClick={() => router.push('/mypage/career/record')}
+      title={TITLE}
+      labelOnClick={() => router.push(HREF)}
       body={
         hasData && latestCareer ? (
           <CareerRecordBody
@@ -59,8 +84,8 @@ const CareerRecordSection = () => {
             height={109}
             description="아직 등록된 커리어가 없어요"
             buttonText="커리어 기록하기"
-            buttonHref="/mypage/career/record"
-            onClick={() => router.push('/mypage/career/record')}
+            buttonHref={HREF}
+            onClick={() => router.push(HREF)}
           />
         )
       }
@@ -68,7 +93,18 @@ const CareerRecordSection = () => {
   );
 };
 
-export default CareerRecordSection;
+const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);
 
 interface CareerRecordBodyProps {
   category: string;
@@ -91,7 +127,6 @@ const CareerRecordBody = ({
 
   return (
     <div className="flex h-[109px] flex-col gap-4">
-      {/* 경력 카테고리 */}
       <div className="flex flex-col gap-2.5">
         <span className="text-xxsmall12 font-normal text-[#4138A3]">
           {category}

--- a/apps/web/src/domain/career-board/sections/ExperienceSection.tsx
+++ b/apps/web/src/domain/career-board/sections/ExperienceSection.tsx
@@ -1,35 +1,68 @@
-import { useGetAllUserExperienceQuery } from '@/api/experience/experience';
+'use client';
+
+import { allUserExperienceQueryOptions } from '@/api/experience/experience';
+import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
 import LoadingContainer from '@/common/loading/LoadingContainer';
 import { getTopCoreCompetencies } from '@/domain/career-board/utils/experienceSummary';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
 
+const TITLE = '경험 정리';
+const HREF = '/mypage/career/experience';
+
 const ExperienceSection = () => {
   const router = useRouter();
 
-  // API 호출
-  const { data, isLoading } = useGetAllUserExperienceQuery(
-    {
-      experienceCategories: [],
-      activityTypes: [],
-      years: [],
-      coreCompetencies: [],
-    },
-    'LATEST',
-    { page: 1, size: 1000 },
+  return (
+    <AsyncBoundary
+      pendingFallback={
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<LoadingContainer text="경험 정리 조회 중" />}
+        />
+      }
+      rejectedFallback={({ resetErrorBoundary }) => (
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<SectionErrorFallback onRetry={resetErrorBoundary} />}
+        />
+      )}
+    >
+      <ExperienceContent />
+    </AsyncBoundary>
+  );
+};
+
+export default ExperienceSection;
+
+const ExperienceContent = () => {
+  const router = useRouter();
+
+  const { data } = useSuspenseQuery(
+    allUserExperienceQueryOptions(
+      {
+        experienceCategories: [],
+        activityTypes: [],
+        years: [],
+        coreCompetencies: [],
+      },
+      'LATEST',
+      { page: 1, size: 1000 },
+    ),
   );
   const { setHasCareerData } = useCareerDataStatus();
 
-  // 사용자가 직접 입력한 경험만 필터링
   const userExperiences =
     data?.userExperiences.filter((exp) => exp.isAddedByAdmin === false) ?? [];
 
   const experienceCount = userExperiences.length;
   const coreCompetencies = getTopCoreCompetencies(data?.userExperiences ?? []);
 
-  // 데이터 존재 여부 확인
   const hasData = experienceCount > 0;
 
   useEffect(() => {
@@ -38,20 +71,10 @@ const ExperienceSection = () => {
     }
   }, [hasData, setHasCareerData]);
 
-  if (isLoading) {
-    return (
-      <CareerCard
-        title="경험 정리"
-        labelOnClick={() => router.push('/mypage/career/experience')}
-        body={<LoadingContainer text="경험 정리 조회 중" />}
-      />
-    );
-  }
-
   return (
     <CareerCard
-      title="경험 정리"
-      labelOnClick={() => router.push('/mypage/career/experience')}
+      title={TITLE}
+      labelOnClick={() => router.push(HREF)}
       body={
         hasData ? (
           <ExperienceBody
@@ -63,8 +86,8 @@ const ExperienceSection = () => {
             height={179}
             description="아직 정리된 경험이 없어요"
             buttonText="경험 정리하기"
-            buttonHref="/mypage/career/experience"
-            onClick={() => router.push('/mypage/career/experience')}
+            buttonHref={HREF}
+            onClick={() => router.push(HREF)}
           />
         )
       }
@@ -72,7 +95,18 @@ const ExperienceSection = () => {
   );
 };
 
-export default ExperienceSection;
+const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);
 
 interface ExperienceBodyProps {
   experienceCount: number;
@@ -85,7 +119,6 @@ const ExperienceBody = ({
 }: ExperienceBodyProps) => {
   return (
     <div className="flex h-[179px] flex-col gap-4">
-      {/* 지금까지 정리한 경험 */}
       <div className="flex flex-col gap-1">
         <span className="text-xxsmall12 font-normal text-[#4138A3]">
           지금까지 정리한 경험
@@ -97,7 +130,6 @@ const ExperienceBody = ({
       </div>
       <div className="border-b border-[#EFEFEF]" />
 
-      {/* 내 주요 핵심 역량 */}
       <div className="flex flex-col gap-2.5">
         <span className="text-xxsmall12 font-normal text-[#4138A3]">
           내 주요 핵심 역량

--- a/apps/web/src/domain/career-board/sections/ExperienceSection.tsx
+++ b/apps/web/src/domain/career-board/sections/ExperienceSection.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
+import { SectionErrorFallback } from '../ui/SectionErrorFallback';
 
 const TITLE = '경험 정리';
 const HREF = '/mypage/career/experience';
@@ -94,19 +95,6 @@ const ExperienceContent = () => {
     />
   );
 };
-
-const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-8">
-    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
-    <button
-      type="button"
-      onClick={onRetry}
-      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
-    >
-      다시 시도
-    </button>
-  </div>
-);
 
 interface ExperienceBodyProps {
   experienceCount: number;

--- a/apps/web/src/domain/career-board/sections/ResumeSection.tsx
+++ b/apps/web/src/domain/career-board/sections/ResumeSection.tsx
@@ -1,20 +1,25 @@
-import { useGetUserDocumentListQuery } from '@/api/user/user';
+'use client';
+
+import { userDocumentListQueryOptions } from '@/api/user/user';
 import { UserDocument } from '@/api/user/userSchema';
+import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
 import LoadingContainer from '@/common/loading/LoadingContainer';
 import { getFileNameFromUrl } from '@/utils/getFileNameFromUrl';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
 
-// 문서 타입을 한국어로 매핑
+const TITLE = '서류 정리';
+const HREF = '/mypage/career/resume';
+
 const DOCUMENT_TYPE_MAP: Record<UserDocument['userDocumentType'], string> = {
   RESUME: '이력서',
   PERSONAL_STATEMENT: '자기소개서',
   PORTFOLIO: '포트폴리오',
 };
 
-// 표시할 문서 타입 순서
 const DOCUMENT_TYPE_ORDER: UserDocument['userDocumentType'][] = [
   'RESUME',
   'PERSONAL_STATEMENT',
@@ -29,15 +34,42 @@ interface Document {
 
 const ResumeSection = () => {
   const router = useRouter();
-  const { data: userDocumentData, isLoading } = useGetUserDocumentListQuery();
+
+  return (
+    <AsyncBoundary
+      pendingFallback={
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<LoadingContainer text="서류 정리 조회 중" />}
+        />
+      }
+      rejectedFallback={({ resetErrorBoundary }) => (
+        <CareerCard
+          title={TITLE}
+          labelOnClick={() => router.push(HREF)}
+          body={<SectionErrorFallback onRetry={resetErrorBoundary} />}
+        />
+      )}
+    >
+      <ResumeContent />
+    </AsyncBoundary>
+  );
+};
+
+export default ResumeSection;
+
+const ResumeContent = () => {
+  const router = useRouter();
+  const { data: userDocumentData } = useSuspenseQuery(
+    userDocumentListQueryOptions,
+  );
   const { setHasCareerData } = useCareerDataStatus();
 
-  // API 응답을 UI 형식으로 변환
   const documents: Document[] = DOCUMENT_TYPE_ORDER.map((docType) => {
     const document = userDocumentData?.userDocumentList.find(
       (doc) => doc.userDocumentType === docType,
     );
-    // fileUrl에서 추출
     const fileName = document?.fileUrl
       ? getFileNameFromUrl(document.userDocumentType, document.fileUrl)
       : null;
@@ -49,7 +81,6 @@ const ResumeSection = () => {
     };
   });
 
-  // 데이터 존재 여부 확인 (fileUrl이 있는지 확인)
   const hasData = documents.some((doc) => doc.fileUrl !== null);
 
   useEffect(() => {
@@ -58,20 +89,10 @@ const ResumeSection = () => {
     }
   }, [hasData, setHasCareerData]);
 
-  if (isLoading) {
-    return (
-      <CareerCard
-        title="서류 정리"
-        labelOnClick={() => router.push('/mypage/career/resume')}
-        body={<LoadingContainer text="서류 정리 조회 중" />}
-      />
-    );
-  }
-
   return (
     <CareerCard
-      title="서류 정리"
-      labelOnClick={() => router.push('/mypage/career/resume')}
+      title={TITLE}
+      labelOnClick={() => router.push(HREF)}
       body={
         hasData ? (
           <ResumeBody documents={documents} />
@@ -80,8 +101,8 @@ const ResumeSection = () => {
             height={109}
             description="아직 등록된 서류가 없어요"
             buttonText="서류 정리하기"
-            buttonHref="/mypage/career/resume"
-            onClick={() => router.push('/mypage/career/resume')}
+            buttonHref={HREF}
+            onClick={() => router.push(HREF)}
           />
         )
       }
@@ -89,7 +110,18 @@ const ResumeSection = () => {
   );
 };
 
-export default ResumeSection;
+const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);
 
 interface ResumeBodyProps {
   documents: Document[];
@@ -98,7 +130,6 @@ interface ResumeBodyProps {
 const ResumeBody = ({ documents }: ResumeBodyProps) => {
   return (
     <div className="flex h-[109px] flex-col gap-4">
-      {/* 내 서류 */}
       <div className="flex flex-col gap-2.5">
         <span className="text-xxsmall12 font-normal text-[#4138A3]">
           내 서류

--- a/apps/web/src/domain/career-board/sections/ResumeSection.tsx
+++ b/apps/web/src/domain/career-board/sections/ResumeSection.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import CareerCard from '../../mypage/career/card/CareerCard';
 import { useCareerDataStatus } from '../contexts/CareerDataStatusContext';
+import { SectionErrorFallback } from '../ui/SectionErrorFallback';
 
 const TITLE = '서류 정리';
 const HREF = '/mypage/career/resume';
@@ -109,20 +110,6 @@ const ResumeContent = () => {
     />
   );
 };
-
-const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
-  <div className="flex flex-col items-center justify-center gap-3 py-8">
-    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
-    <button
-      type="button"
-      onClick={onRetry}
-      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
-    >
-      다시 시도
-    </button>
-  </div>
-);
-
 interface ResumeBodyProps {
   documents: Document[];
 }

--- a/apps/web/src/domain/career-board/ui/SectionErrorFallback.tsx
+++ b/apps/web/src/domain/career-board/ui/SectionErrorFallback.tsx
@@ -1,0 +1,12 @@
+export const SectionErrorFallback = ({ onRetry }: { onRetry: () => void }) => (
+  <div className="flex flex-col items-center justify-center gap-3 py-8">
+    <p className="text-xsmall14 text-neutral-40">불러오지 못했어요.</p>
+    <button
+      type="button"
+      onClick={onRetry}
+      className="rounded-xs border-neutral-80 text-xsmall14 text-neutral-20 border px-4 py-2 font-medium"
+    >
+      다시 시도
+    </button>
+  </div>
+);


### PR DESCRIPTION
- 5개 sections(CareerPlan/Record/Resume/Experience/Growth) AsyncBoundary로 격리
- 각 섹션을 Section(외피) + Content(useSuspenseQuery) 구조로 분할
- 섹션별 SectionErrorFallback(다시시도 버튼) 추가로 에러 복구 가능
- CareerGrowthSection: LIBRARY 탭만 nested AsyncBoundary로 lazy fetch
- API queryOptions 팩토리 5개 추가(기존 hook 시그니처 보존)
  - userQueryOptions, userDocumentListQueryOptions
  - userCareerQueryOptions, allUserExperienceQueryOptions
  - mypageApplicationsQueryOptions, mypageMagnetListQueryOptions

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3026]

[LC-3026]:https://letscareer-team.atlassian.net/browse/LC-3026


[LC-3026]: https://letscareer-team.atlassian.net/browse/LC-3026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3026]: https://letscareer-team.atlassian.net/browse/LC-3026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ