### PR TITLE
LC-3041 sentry 커스텀 에러 클래스 도입 및 주요 비즈니스 로직 에러 핸들링 고도화

### DIFF
--- a/apps/web/src/app/api/notify-digest/route.ts
+++ b/apps/web/src/app/api/notify-digest/route.ts
@@ -26,7 +26,11 @@ export async function GET(request: NextRequest) {
 
   const entries = flushAll();
   if (entries.length === 0) {
-    return Response.json({ success: true, count: 0, message: '집계 항목 없음' });
+    return Response.json({
+      success: true,
+      count: 0,
+      message: '집계 항목 없음',
+    });
   }
 
   const webhookUrl =

--- a/apps/web/src/app/api/notify-digest/route.ts
+++ b/apps/web/src/app/api/notify-digest/route.ts
@@ -1,9 +1,5 @@
 import { NextRequest } from 'next/server';
-import {
-  clearAll,
-  peekAll,
-  type DedupeEntry,
-} from '@/utils/errorDedupe';
+import { clearAll, peekAll, type DedupeEntry } from '@/utils/errorDedupe';
 
 const DIGEST_TOP_N = 20;
 const DIGEST_MESSAGE_PREVIEW_MAX = 200;
@@ -55,7 +51,11 @@ export async function GET(request: NextRequest) {
 
   const entries = peekAll();
   if (entries.length === 0) {
-    return Response.json({ success: true, count: 0, message: '집계 항목 없음' });
+    return Response.json({
+      success: true,
+      count: 0,
+      message: '집계 항목 없음',
+    });
   }
 
   const webhookUrl =

--- a/apps/web/src/app/api/notify-digest/route.ts
+++ b/apps/web/src/app/api/notify-digest/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from 'next/server';
+import { flushAll, type DedupeEntry } from '@/utils/errorDedupe';
+
+/**
+ * 누적된 dedupe 에러를 Slack 으로 일괄 발송하는 cron 엔드포인트.
+ * Vercel Cron 이 매일 새벽에 GET 으로 호출.
+ *
+ * 인증: `CRON_SECRET` 환경변수 설정 시 `Authorization: Bearer <secret>` 헤더 검증.
+ *       (Vercel Cron 은 자동으로 이 헤더를 주입한다.)
+ *
+ * 한계: errorDedupe 의 Map 이 모듈 레벨이라 cron 호출 시점에 warm 상태인
+ *       단일 인스턴스의 store 만 flush 된다 (apps/web/src/utils/errorDedupe.ts 의
+ *       주석 참조).
+ */
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return Response.json(
+        { success: false, message: 'Unauthorized' },
+        { status: 401 },
+      );
+    }
+  }
+
+  const entries = flushAll();
+  if (entries.length === 0) {
+    return Response.json({ success: true, count: 0, message: '집계 항목 없음' });
+  }
+
+  const webhookUrl =
+    process.env.NEXT_PUBLIC_ERROR_WEBHOOK_URL || process.env.ERROR_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.warn('[Digest] ERROR_WEBHOOK_URL 미설정 — digest 발송 불가');
+    return Response.json({
+      success: false,
+      count: entries.length,
+      message: 'webhook 미설정',
+    });
+  }
+
+  const message = formatDigestForSlack(entries);
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(message),
+    });
+    if (!res.ok) {
+      throw new Error(`Slack ${res.status} ${res.statusText}`);
+    }
+    return Response.json({ success: true, count: entries.length });
+  } catch (e) {
+    console.error('[Digest] Slack 발송 실패', e);
+    return Response.json(
+      {
+        success: false,
+        count: entries.length,
+        error: e instanceof Error ? e.message : String(e),
+      },
+      { status: 500 },
+    );
+  }
+}
+
+const escapeSlack = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/@(channel|here|everyone)/gi, '(at)$1');
+
+const hhmm = (iso: string): string => iso.slice(11, 16);
+
+function formatDigestForSlack(entries: DedupeEntry[]) {
+  const today = new Date().toISOString().slice(0, 10);
+  const sorted = [...entries].sort((a, b) => b.count - a.count);
+  const top = sorted.slice(0, 20);
+  const totalEvents = entries.reduce((sum, e) => sum + e.count, 0);
+
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: `📊 일일 에러 디제스트 (${today})` },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `고유 *${entries.length}건* / 총 *${totalEvents}회* 발생`,
+      },
+    },
+    { type: 'divider' },
+    ...top.map((e) => ({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          `*${escapeSlack(e.name)}* — ${escapeSlack(e.message.slice(0, 200))}\n` +
+          `📊 *${e.count}회* (첫: ${hhmm(e.firstSeen)} / 마지막: ${hhmm(e.lastSeen)})`,
+      },
+    })),
+  ];
+
+  if (entries.length > 20) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `상위 20건만 표시 (전체 ${entries.length}건)`,
+        },
+      ],
+    });
+  }
+
+  return {
+    text: `📊 일일 에러 디제스트 (${today}) — 고유 ${entries.length}건 / 총 ${totalEvents}회`,
+    blocks,
+  };
+}

--- a/apps/web/src/app/api/notify-digest/route.ts
+++ b/apps/web/src/app/api/notify-digest/route.ts
@@ -1,19 +1,48 @@
 import { NextRequest } from 'next/server';
-import { flushAll, type DedupeEntry } from '@/utils/errorDedupe';
+import {
+  clearAll,
+  peekAll,
+  type DedupeEntry,
+} from '@/utils/errorDedupe';
+
+const DIGEST_TOP_N = 20;
+const DIGEST_MESSAGE_PREVIEW_MAX = 200;
 
 /**
  * 누적된 dedupe 에러를 Slack 으로 일괄 발송하는 cron 엔드포인트.
- * Vercel Cron 이 매일 새벽에 GET 으로 호출.
+ * Vercel Cron 이 `vercel.json` 의 schedule 에 따라 GET 으로 호출.
  *
- * 인증: `CRON_SECRET` 환경변수 설정 시 `Authorization: Bearer <secret>` 헤더 검증.
- *       (Vercel Cron 은 자동으로 이 헤더를 주입한다.)
+ * 인증:
+ *  - production: `CRON_SECRET` 환경변수 필수. 미설정 시 500.
+ *    (무인증 노출 시 누구나 GET 으로 store flush + Slack 스팸 발송 가능)
+ *  - non-production: `CRON_SECRET` 미설정이어도 동작 (테스트 편의).
+ *  - Vercel Cron 은 자동으로 `Authorization: Bearer <CRON_SECRET>` 헤더 주입.
  *
- * 한계: errorDedupe 의 Map 이 모듈 레벨이라 cron 호출 시점에 warm 상태인
- *       단일 인스턴스의 store 만 flush 된다 (apps/web/src/utils/errorDedupe.ts 의
- *       주석 참조).
+ * 발송 패턴 (peek → 성공 시 clear):
+ *  - peekAll() 로 non-destructive read
+ *  - webhook 성공 시에만 clearAll() — 실패 시 store 보존하여 다음 cron 재시도.
+ *
+ * 한계: errorDedupe 의 module Map 은 같은 lambda 인스턴스에서만 공유됨.
+ *       다른 route handler(POST send-error-webhook)와 별 lambda 로 분리 deploy
+ *       될 수 있어 store 비어있을 수 있음 (errorDedupe.ts 주석 참조).
  */
 export async function GET(request: NextRequest) {
   const cronSecret = process.env.CRON_SECRET;
+  const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+
+  if (isProduction && !cronSecret) {
+    console.error(
+      '[Digest] production 에서 CRON_SECRET 미설정 — 무인증 위험으로 차단',
+    );
+    return Response.json(
+      {
+        success: false,
+        message: 'CRON_SECRET 환경변수가 production 에서 설정되지 않았습니다.',
+      },
+      { status: 500 },
+    );
+  }
+
   if (cronSecret) {
     const authHeader = request.headers.get('authorization');
     if (authHeader !== `Bearer ${cronSecret}`) {
@@ -24,13 +53,9 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const entries = flushAll();
+  const entries = peekAll();
   if (entries.length === 0) {
-    return Response.json({
-      success: true,
-      count: 0,
-      message: '집계 항목 없음',
-    });
+    return Response.json({ success: true, count: 0, message: '집계 항목 없음' });
   }
 
   const webhookUrl =
@@ -55,9 +80,11 @@ export async function GET(request: NextRequest) {
     if (!res.ok) {
       throw new Error(`Slack ${res.status} ${res.statusText}`);
     }
+    // 성공 시에만 store 비움 — 실패 시엔 보존하여 다음 cron / 수동 retry 가능.
+    clearAll();
     return Response.json({ success: true, count: entries.length });
   } catch (e) {
-    console.error('[Digest] Slack 발송 실패', e);
+    console.error('[Digest] Slack 발송 실패 — store 유지', e);
     return Response.json(
       {
         success: false,
@@ -74,14 +101,32 @@ const escapeSlack = (s: string): string =>
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/@(channel|here|everyone)/gi, '(at)$1');
+    // 특정 멘션(@channel/@here/@everyone) 만 막지 말고 모든 @ 를 중화하여
+    // 의도치 않은 사용자 멘션·DM 트리거 방지.
+    .replace(/@/g, '(at)');
 
-const hhmm = (iso: string): string => iso.slice(11, 16);
+// 표시 시각은 KST 기준 (운영진이 한국 시간으로 보는 게 자연스러움).
+const hhmmKst = (iso: string): string =>
+  new Date(iso).toLocaleTimeString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+const todayKst = (): string =>
+  new Date().toLocaleDateString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
 
 function formatDigestForSlack(entries: DedupeEntry[]) {
-  const today = new Date().toISOString().slice(0, 10);
-  const sorted = [...entries].sort((a, b) => b.count - a.count);
-  const top = sorted.slice(0, 20);
+  const today = todayKst();
+  // peekAll() 가 이미 새 배열을 반환하므로 추가 복사 불필요.
+  const sorted = entries.sort((a, b) => b.count - a.count);
+  const top = sorted.slice(0, DIGEST_TOP_N);
   const totalEvents = entries.reduce((sum, e) => sum + e.count, 0);
 
   const blocks: Array<Record<string, unknown>> = [
@@ -102,19 +147,19 @@ function formatDigestForSlack(entries: DedupeEntry[]) {
       text: {
         type: 'mrkdwn',
         text:
-          `*${escapeSlack(e.name)}* — ${escapeSlack(e.message.slice(0, 200))}\n` +
-          `📊 *${e.count}회* (첫: ${hhmm(e.firstSeen)} / 마지막: ${hhmm(e.lastSeen)})`,
+          `*${escapeSlack(e.name)}* — ${escapeSlack(e.message.slice(0, DIGEST_MESSAGE_PREVIEW_MAX))}\n` +
+          `📊 *${e.count}회* (첫: ${hhmmKst(e.firstSeen)} / 마지막: ${hhmmKst(e.lastSeen)})`,
       },
     })),
   ];
 
-  if (entries.length > 20) {
+  if (entries.length > DIGEST_TOP_N) {
     blocks.push({
       type: 'context',
       elements: [
         {
           type: 'mrkdwn',
-          text: `상위 20건만 표시 (전체 ${entries.length}건)`,
+          text: `상위 ${DIGEST_TOP_N}건만 표시 (전체 ${entries.length}건)`,
         },
       ],
     });

--- a/apps/web/src/app/api/send-error-webhook/route.ts
+++ b/apps/web/src/app/api/send-error-webhook/route.ts
@@ -1,8 +1,5 @@
 import { sendErrorToWebhook } from '@/utils/webhook';
-import {
-  buildSignature,
-  recordAndCheckFirst,
-} from '@/utils/errorDedupe';
+import { buildSignature, recordAndCheckFirst } from '@/utils/errorDedupe';
 import { headers } from 'next/headers';
 import { NextRequest } from 'next/server';
 
@@ -41,10 +38,7 @@ export async function POST(request: NextRequest) {
 
     // crash 가 아닌 경우만 dedupe — 첫 발생 send, 반복은 카운트만.
     if (!isCrash) {
-      const signature = buildSignature(
-        error.name || 'Error',
-        error.message,
-      );
+      const signature = buildSignature(error.name || 'Error', error.message);
       const isFirst = recordAndCheckFirst(signature, {
         name: error.name || 'Error',
         message: error.message,

--- a/apps/web/src/app/api/send-error-webhook/route.ts
+++ b/apps/web/src/app/api/send-error-webhook/route.ts
@@ -1,9 +1,18 @@
 import { sendErrorToWebhook } from '@/utils/webhook';
+import {
+  buildSignature,
+  recordAndCheckFirst,
+} from '@/utils/errorDedupe';
 import { headers } from 'next/headers';
 import { NextRequest } from 'next/server';
 
 /**
- * 클라이언트 사이드에서 발생한 에러를 webhook으로 전송하는 API 엔드포인트
+ * 클라이언트 사이드에서 발생한 에러를 webhook으로 전송하는 API 엔드포인트.
+ *
+ * 발송 정책:
+ *  - tags.crash === 'true' (세션 crash) → dedupe 우회, 항상 즉시 Slack
+ *  - 첫 발생 (signature 처음 본 것) → 즉시 Slack
+ *  - 반복 (이미 본 signature) → 카운트만 증가, /api/notify-digest 가 야간 일괄 발송
  */
 export async function POST(request: NextRequest) {
   try {
@@ -27,6 +36,26 @@ export async function POST(request: NextRequest) {
       return Response.json({ success: true, ignored: true });
     }
 
+    // crash 태그는 instrumentation-client.ts beforeSend 가 isCrashEvent 결과로 부착.
+    const isCrash = tags?.crash === 'true' || tags?.crash === true;
+
+    // crash 가 아닌 경우만 dedupe — 첫 발생 send, 반복은 카운트만.
+    if (!isCrash) {
+      const signature = buildSignature(
+        error.name || 'Error',
+        error.message,
+      );
+      const isFirst = recordAndCheckFirst(signature, {
+        name: error.name || 'Error',
+        message: error.message,
+        url,
+        userAgent,
+      });
+      if (!isFirst) {
+        return Response.json({ success: true, deduped: true });
+      }
+    }
+
     // Error 객체 재구성
     const errorObj = new Error(error.message);
     errorObj.name = error.name || 'Error';
@@ -45,7 +74,7 @@ export async function POST(request: NextRequest) {
       extra,
     });
 
-    return Response.json({ success: true });
+    return Response.json({ success: true, sent: true, crash: isCrash });
   } catch (error) {
     console.error('[API] Webhook 전송 실패:', error);
     return Response.json(

--- a/apps/web/src/app/api/send-error-webhook/route.ts
+++ b/apps/web/src/app/api/send-error-webhook/route.ts
@@ -34,7 +34,8 @@ export async function POST(request: NextRequest) {
     }
 
     // crash 태그는 instrumentation-client.ts beforeSend 가 isCrashEvent 결과로 부착.
-    const isCrash = tags?.crash === 'true' || tags?.crash === true;
+    // normalizeSentryTags 가 모든 태그 값을 문자열로 변환하므로 'true' 비교만으로 충분.
+    const isCrash = tags?.crash === 'true';
 
     // crash 가 아닌 경우만 dedupe — 첫 발생 send, 반복은 카운트만.
     if (!isCrash) {

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -74,9 +74,11 @@ Sentry.init({
     // 1) production 환경이 아니면 무조건 차단 (preview/dev 운영 채널 오염 방지)
     // 2) production 이어도, crash 가 아니고 noise 분류된 경우 차단
     //    (crash 면 noise 라벨과 무관하게 항상 발송 — 사용자 영향 우선)
-    const isProduction =
-      process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ||
-      process.env.NODE_ENV === 'production';
+    //
+    // Vercel preview/dev 빌드도 NODE_ENV='production' 으로 빌드되므로
+    // NODE_ENV 만으로는 운영 구분이 안 됨. NEXT_PUBLIC_VERCEL_ENV 만을
+    // single source of truth 로 사용 (값 없으면 non-production 으로 간주).
+    const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
     const shouldSkipWebhook =
       !isProduction || (!isCrash && noiseCategory !== null);
 

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -54,18 +54,37 @@ Sentry.init({
 
   // 에러를 Sentry로 보내기 전에 webhook으로도 전송
   beforeSend(event, hint) {
-    // noise 분류 태그 부착 (drop 하지 않음 — 격리만)
+    // noise 분류 태그 부착 (Sentry 대시보드에는 격리되어 들어감, drop 안 함)
+    let noiseCategory: ReturnType<typeof classifyNoise> = null;
     if (hint.originalException instanceof Error) {
-      const noise = classifyNoise(hint.originalException);
-      if (noise) {
-        event.tags = { ...event.tags, noise };
+      noiseCategory = classifyNoise(hint.originalException);
+      if (noiseCategory) {
+        event.tags = { ...event.tags, noise: noiseCategory };
       }
     }
+
+    // 사용자 세션 crash (페이지 사용 불가 수준)인지 분류 → tag 부착
+    // 이 태그가 있으면 route.ts 의 dedupe 가 우회되어 항상 즉시 Slack 발송.
+    const isCrash = isCrashEvent(event);
+    if (isCrash) {
+      event.tags = { ...event.tags, crash: 'true' };
+    }
+
+    // Slack webhook 발송 차단 조건:
+    // 1) production 환경이 아니면 무조건 차단 (preview/dev 운영 채널 오염 방지)
+    // 2) production 이어도, crash 가 아니고 noise 분류된 경우 차단
+    //    (crash 면 noise 라벨과 무관하게 항상 발송 — 사용자 영향 우선)
+    const isProduction =
+      process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ||
+      process.env.NODE_ENV === 'production';
+    const shouldSkipWebhook =
+      !isProduction || (!isCrash && noiseCategory !== null);
 
     // 에러 객체가 있는 경우 webhook으로 전송 (클라이언트 사이드는 API 라우트를 통해)
     if (
       hint.originalException instanceof Error &&
-      typeof window !== 'undefined'
+      typeof window !== 'undefined' &&
+      !shouldSkipWebhook
     ) {
       const error = hint.originalException;
 

--- a/apps/web/src/utils/errorDedupe.ts
+++ b/apps/web/src/utils/errorDedupe.ts
@@ -1,0 +1,78 @@
+/**
+ * 에러 webhook dedupe — 동일 signature(name + message 200자) 반복 발생 시
+ * 카운트만 누적하고 Slack 즉시 발송은 차단. 야간 cron `/api/notify-digest` 가
+ * `flushAll()` 로 일괄 digest 형태로 발송.
+ *
+ * 정책:
+ *  - 첫 발생: send (true 리턴)
+ *  - 반복:    skip (false 리턴, count++)
+ *  - crash 분류 이벤트는 호출 단(route.ts)에서 dedupe 자체를 우회시킨다.
+ *
+ * 한계 (인지하고 사용):
+ *  - 모듈 레벨 Map 이라 *단일 Node 인스턴스* 내에서만 공유. Vercel 다중 서버리스
+ *    인스턴스 환경에선 인스턴스마다 별개 카운터 → "처음 본 에러" 가 인스턴스 수만큼
+ *    Slack 으로 갈 수 있음. 그래도 무방비 폭주 대비 큰 폭 감소.
+ *  - cron flush 도 그 시점 warm 상태인 인스턴스 1개의 store 만 비움.
+ *  - 진짜 글로벌 dedupe 가 필요해지면 Vercel KV / Upstash Redis 로 이전.
+ *    인터페이스(buildSignature/recordAndCheckFirst/flushAll)는 그대로 유지.
+ */
+
+export type DedupeEntry = {
+  signature: string;
+  name: string;
+  message: string;
+  count: number;
+  firstSeen: string;
+  lastSeen: string;
+  sampleUrl?: string;
+  sampleUserAgent?: string;
+};
+
+const store = new Map<string, DedupeEntry>();
+
+export function buildSignature(name: string, message: string): string {
+  return `${name}::${message.slice(0, 200)}`;
+}
+
+/**
+ * @returns true 이면 첫 발생(send 권장), false 이면 반복(skip, 카운트만 증가).
+ */
+export function recordAndCheckFirst(
+  signature: string,
+  sample: {
+    name: string;
+    message: string;
+    url?: string;
+    userAgent?: string;
+  },
+): boolean {
+  const now = new Date().toISOString();
+  const existing = store.get(signature);
+
+  if (existing) {
+    existing.count += 1;
+    existing.lastSeen = now;
+    return false;
+  }
+
+  store.set(signature, {
+    signature,
+    name: sample.name,
+    message: sample.message,
+    count: 1,
+    firstSeen: now,
+    lastSeen: now,
+    sampleUrl: sample.url,
+    sampleUserAgent: sample.userAgent,
+  });
+  return true;
+}
+
+/**
+ * 누적된 dedupe entries 모두 반환하고 store 비움. cron digest 에서 호출.
+ */
+export function flushAll(): DedupeEntry[] {
+  const entries = Array.from(store.values());
+  store.clear();
+  return entries;
+}

--- a/apps/web/src/utils/errorDedupe.ts
+++ b/apps/web/src/utils/errorDedupe.ts
@@ -1,21 +1,28 @@
 /**
- * 에러 webhook dedupe — 동일 signature(name + message 200자) 반복 발생 시
- * 카운트만 누적하고 Slack 즉시 발송은 차단. 야간 cron `/api/notify-digest` 가
- * `flushAll()` 로 일괄 digest 형태로 발송.
+ * 에러 webhook dedupe — 동일 signature(name + message ERROR_SIGNATURE_MAX_LENGTH자)
+ * 반복 발생 시 카운트만 누적하고 Slack 즉시 발송은 차단. 야간 cron
+ * `/api/notify-digest` 가 `flushAll()` 로 일괄 digest 형태 Slack 발송.
  *
  * 정책:
  *  - 첫 발생: send (true 리턴)
  *  - 반복:    skip (false 리턴, count++)
  *  - crash 분류 이벤트는 호출 단(route.ts)에서 dedupe 자체를 우회시킨다.
  *
- * 한계 (인지하고 사용):
- *  - 모듈 레벨 Map 이라 *단일 Node 인스턴스* 내에서만 공유. Vercel 다중 서버리스
- *    인스턴스 환경에선 인스턴스마다 별개 카운터 → "처음 본 에러" 가 인스턴스 수만큼
- *    Slack 으로 갈 수 있음. 그래도 무방비 폭주 대비 큰 폭 감소.
- *  - cron flush 도 그 시점 warm 상태인 인스턴스 1개의 store 만 비움.
- *  - 진짜 글로벌 dedupe 가 필요해지면 Vercel KV / Upstash Redis 로 이전.
- *    인터페이스(buildSignature/recordAndCheckFirst/flushAll)는 그대로 유지.
+ * 한계 (운영 시 인지 필요):
+ *  1) **모듈 레벨 Map** — 단일 Node 인스턴스 내에서만 공유.
+ *  2) **Next.js App Router 의 route handler 별 함수 격리** — Vercel 에서
+ *     `/api/send-error-webhook` (POST) 와 `/api/notify-digest` (GET) 이
+ *     서로 다른 서버리스 함수로 배포되면 module store 가 *공유되지 않는다*.
+ *     이 경우 GET 측 store 는 항상 비어있어 digest 가 발송되지 않을 수 있음.
+ *     → 운영에서 정상 동작 검증 필요. 검증 결과 분리되어 있으면 외부 store 필수.
+ *  3) **다중 인스턴스 cold start** — 같은 함수여도 인스턴스 수만큼 별개 store.
+ *
+ *  **글로벌 dedupe 가 필요해지면 Upstash Redis 또는 Vercel KV 로 이전한다.**
+ *  인터페이스(buildSignature/recordAndCheckFirst/peekAll/clearAll/flushAll)는
+ *  그대로 유지하므로 callsite 변경 최소화 가능.
  */
+
+export const ERROR_SIGNATURE_MAX_LENGTH = 200;
 
 export type DedupeEntry = {
   signature: string;
@@ -31,7 +38,7 @@ export type DedupeEntry = {
 const store = new Map<string, DedupeEntry>();
 
 export function buildSignature(name: string, message: string): string {
-  return `${name}::${message.slice(0, 200)}`;
+  return `${name}::${message.slice(0, ERROR_SIGNATURE_MAX_LENGTH)}`;
 }
 
 /**
@@ -69,10 +76,26 @@ export function recordAndCheckFirst(
 }
 
 /**
- * 누적된 dedupe entries 모두 반환하고 store 비움. cron digest 에서 호출.
+ * Non-destructive read. cron digest 가 webhook 발송 *성공 후* `clearAll()` 호출.
+ * 발송 실패 시 store 보존되어 다음 cron 또는 수동 retry 가능.
+ */
+export function peekAll(): DedupeEntry[] {
+  return Array.from(store.values());
+}
+
+/**
+ * Store 비움. 발송 성공 후에만 호출.
+ */
+export function clearAll(): void {
+  store.clear();
+}
+
+/**
+ * peek + clear 묶음. 호출 후 entries 손실 가능성이 있으므로 webhook 발송이
+ * 보장된 흐름에서만 사용 권장. 신규 코드는 peekAll/clearAll 분리 사용 선호.
  */
 export function flushAll(): DedupeEntry[] {
-  const entries = Array.from(store.values());
-  store.clear();
+  const entries = peekAll();
+  clearAll();
   return entries;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -67,7 +67,7 @@
   "crons": [
     {
       "path": "/api/notify-digest",
-      "schedule": "0 17 * * *"
+      "schedule": "0 23 * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -63,5 +63,11 @@
         }
       ]
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/notify-digest",
+      "schedule": "0 17 * * *"
+    }
   ]
 }


### PR DESCRIPTION
알림 폭주 대응:
- noise 분류된 이벤트 (번역기/지갑/stale-chunk) 는 Slack webhook 차단, Sentry 대시보드에는 noise 태그 격리 상태로 그대로 보존.
- production 환경 외 (preview/dev) 는 webhook 차단으로 운영 채널 오염 방지.
- 동일 signature(name + message 200자) 반복 발생은 in-memory 카운트만 누적, /api/notify-digest 가 매일 새벽(UTC 17:00 = KST 02:00) Vercel Cron 으로 일괄 digest 형태 Slack 발송. 첫 발생만 즉시 알림.

세션 crash 예외:
- isCrashEvent (level=fatal / unhandled / RSC server-component / ChunkLoadError / *_PARSE) 로 판정된 이벤트는 instrumentation-client.ts beforeSend 가 crash 태그 부착, route.ts 가 dedupe 우회하여 항상 즉시 Slack.

errorDedupe 한계 (모듈 레벨 Map → 단일 인스턴스 스코프) 는 utils 주석에 명시. 다중 인스턴스 글로벌 dedupe 가 필요해지면 Vercel KV / Upstash Redis 로 이전, 인터페이스 buildSignature/recordAndCheckFirst/flushAll 는 그대로 유지.

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3041]

[LC-3041]:https://letscareer-team.atlassian.net/browse/LC-3041


[LC-3041]: https://letscareer-team.atlassian.net/browse/LC-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3041]: https://letscareer-team.atlassian.net/browse/LC-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ