### PR TITLE
fix(sentry): 서버 beforeSend 에 client 와 동일한 crash-only Slack 게이트 적용

### DIFF
--- a/apps/web/sentry.server.config.test.ts
+++ b/apps/web/sentry.server.config.test.ts
@@ -1,0 +1,57 @@
+/**
+ * sentry.server.config.ts 정책 회귀 방지 테스트.
+ *
+ * 배경: BE 5xx 가 RSC catch 블록 안에서 처리되어도 axios throw 시점에 Sentry
+ * server SDK 가 자동 캡처하여 events 가 만들어지고, 과거 server beforeSend 는
+ * production 이면 무조건 Slack webhook 으로 발송했음. 결과적으로 동일한 BE 5xx
+ * 가 매번 운영 Slack 에 알림되어 진짜 crash 알림이 묻히는 cry-wolf 발생.
+ *
+ * 본 테스트는 client(instrumentation-client.ts)와 server(sentry.server.config.ts)
+ * 정책이 비대칭으로 회귀하지 않도록 정적 검증한다. beforeSend 가 Sentry.init
+ * 옵션 객체 내부에 inline 으로 정의되어 있어 unit-level 호출 검증이 어렵기
+ * 때문에 소스 패턴 검증으로 대체한다.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sentry.server.config 정책 회귀 방지', () => {
+  const filePath = path.join(__dirname, 'sentry.server.config.ts');
+  const source = fs.readFileSync(filePath, 'utf-8');
+
+  it('isCrashEvent import 가 존재한다 (handled BE 에러 Slack 차단의 핵심 게이트)', () => {
+    expect(source).toMatch(
+      /from\s+['"]\.\/src\/utils\/replayCrashFilter['"]/,
+    );
+    expect(source).toContain('isCrashEvent');
+  });
+
+  it('NEXT_PUBLIC_VERCEL_ENV === "production" 환경 체크를 사용한다 (Vercel preview 오염 방지)', () => {
+    expect(source).toMatch(
+      /NEXT_PUBLIC_VERCEL_ENV[\s\S]*?===[\s\S]*?['"]production['"]/,
+    );
+  });
+
+  it('isProduction + isCrash + !isNoise 3중 게이트가 함께 존재한다', () => {
+    expect(source).toContain('isProduction');
+    expect(source).toContain('isCrash');
+    expect(source).toContain('!isNoise');
+  });
+
+  it('NODE_ENV 단독 체크로만 webhook 차단하던 과거 정책으로 회귀하지 않는다', () => {
+    // 과거 코드: `if (process.env.NODE_ENV === 'development') return event;`
+    // 이 패턴만 존재하고 isCrashEvent 게이트가 없으면 BE 5xx 가 모두 Slack 으로 감.
+    const hasOnlyNodeEnvCheck = /process\.env\.NODE_ENV\s*===\s*['"]development['"]/.test(
+      source,
+    );
+    if (hasOnlyNodeEnvCheck) {
+      // NODE_ENV 체크가 남아있어도 무방하지만, 반드시 isCrashEvent 게이트가 함께 있어야 한다.
+      expect(source).toContain('isCrashEvent');
+    }
+  });
+
+  it('classifyNoise 결과를 noise 차단(!isNoise) 에 활용한다 (태그만 부착하고 발송하던 회귀 방지)', () => {
+    expect(source).toContain('classifyNoise');
+    expect(source).toContain('isNoise = true');
+    expect(source).toContain('!isNoise');
+  });
+});

--- a/apps/web/sentry.server.config.test.ts
+++ b/apps/web/sentry.server.config.test.ts
@@ -19,9 +19,7 @@ describe('sentry.server.config 정책 회귀 방지', () => {
   const source = fs.readFileSync(filePath, 'utf-8');
 
   it('isCrashEvent import 가 존재한다 (handled BE 에러 Slack 차단의 핵심 게이트)', () => {
-    expect(source).toMatch(
-      /from\s+['"]\.\/src\/utils\/replayCrashFilter['"]/,
-    );
+    expect(source).toMatch(/from\s+['"]\.\/src\/utils\/replayCrashFilter['"]/);
     expect(source).toContain('isCrashEvent');
   });
 
@@ -40,9 +38,8 @@ describe('sentry.server.config 정책 회귀 방지', () => {
   it('NODE_ENV 단독 체크로만 webhook 차단하던 과거 정책으로 회귀하지 않는다', () => {
     // 과거 코드: `if (process.env.NODE_ENV === 'development') return event;`
     // 이 패턴만 존재하고 isCrashEvent 게이트가 없으면 BE 5xx 가 모두 Slack 으로 감.
-    const hasOnlyNodeEnvCheck = /process\.env\.NODE_ENV\s*===\s*['"]development['"]/.test(
-      source,
-    );
+    const hasOnlyNodeEnvCheck =
+      /process\.env\.NODE_ENV\s*===\s*['"]development['"]/.test(source);
     if (hasOnlyNodeEnvCheck) {
       // NODE_ENV 체크가 남아있어도 무방하지만, 반드시 isCrashEvent 게이트가 함께 있어야 한다.
       expect(source).toContain('isCrashEvent');

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
+import { isCrashEvent } from './src/utils/replayCrashFilter';
 import { normalizeSentryTags, classifyNoise } from './src/utils/sentry';
 import { shouldSendLog } from './src/utils/sentryLogSampler';
 import { sendErrorToWebhook } from './src/utils/webhook';
@@ -23,26 +24,42 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: false,
 
-  // 에러를 Sentry로 보내기 전에 webhook으로도 전송
+  // 에러를 Sentry 로는 모두 전송하되, Slack webhook 은 사용자 영향 큰 crash 만.
+  // 클라이언트(instrumentation-client.ts) 정책과 일치시켜 server / client 비대칭 제거.
+  // 정책:
+  //  - production 외 (preview/dev)         → Slack 차단
+  //  - noise 분류 (번역기/지갑/stale-chunk) → Slack 차단 (Sentry 태그만 부착)
+  //  - non-crash (catch 가능한 일반 BE 에러) → Slack 차단 (Sentry 대시보드만)
+  //  - production + crash + non-noise       → Slack 발송
+  // crash 기준은 isCrashEvent (replayCrashFilter.ts):
+  //   level=fatal / unhandled / server-component / ChunkLoadError / *_PARSE
+  //
+  // 변경 사유: BE 5xx 응답이 RSC catch 블록 안에서 처리되어도 axios throw 시점에
+  //   Sentry server SDK 가 자동 캡처하여 events 가 만들어지고, 기존 server beforeSend
+  //   는 production 이면 무조건 Slack 으로 발송했음. 결과적으로 동일한 BE 5xx 가
+  //   매번 운영 Slack 에 알림되어 진짜 crash 알림이 묻히는 cry-wolf 상황 발생.
   beforeSend(event, hint) {
-    // noise 분류 태그 부착 (drop 하지 않음 — 격리만)
+    // noise 분류 태그 부착 (Sentry 대시보드 필터링용 — drop X)
+    let isNoise = false;
     if (hint.originalException instanceof Error) {
       const noise = classifyNoise(hint.originalException);
       if (noise) {
         event.tags = { ...event.tags, noise };
+        isNoise = true;
       }
     }
 
-    // 개발 환경에서는 webhook 전송하지 않음
-    if (process.env.NODE_ENV === 'development') {
-      return event;
-    }
+    const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+    const isCrash = isCrashEvent(event);
+    const shouldSendWebhook =
+      isProduction &&
+      isCrash &&
+      !isNoise &&
+      hint.originalException instanceof Error;
 
-    // 에러 객체가 있는 경우 webhook으로 전송
-    if (hint.originalException instanceof Error) {
-      const error = hint.originalException;
+    if (shouldSendWebhook) {
+      const error = hint.originalException as Error;
 
-      // 요청 정보 추출 (API 라우트인 경우)
       const requestUrl =
         event.request?.url ||
         (event.contexts?.request?.url as string | undefined) ||
@@ -59,7 +76,6 @@ Sentry.init({
         tags: normalizeSentryTags(event.tags),
         extra: {
           ...event.extra,
-          // 추가 컨텍스트 정보
           sentryEventId: event.event_id,
           release: event.release,
           environment: event.environment,
@@ -70,7 +86,7 @@ Sentry.init({
       });
     }
 
-    // Sentry로도 계속 전송
+    // Sentry 로는 모든 이벤트 그대로 전송 (대시보드 가시성 유지)
     return event;
   },
 });


### PR DESCRIPTION
문제:
- 운영 Slack 에 "서버 내부 오류입니다" 등 BE 5xx 에러가 반복적으로 알림됨.
- 원인: client(instrumentation-client.ts) 는 production + isCrash + non-noise 3중 게이트 통과만 webhook 발송하는 반면, server(sentry.server.config.ts) 는 NODE_ENV !== 'development' 만 체크하고 모든 에러를 Slack 으로 발송.
- RSC(예: LibraryDetailPage) 의 catch 블록에서 처리된 BE 5xx 도 axios throw 시점에 Sentry server SDK 가 자동 캡처 → 모두 Slack 발송 → 진짜 crash 알림이 노이즈에 묻히는 cry-wolf 상황.

수정 (sentry.server.config.ts):
- isCrashEvent (replayCrashFilter) import 추가.
- beforeSend 정책을 client 와 동일하게 통일:
  * production 외 (preview/dev)         → Slack 차단
  * noise 분류 (번역기/지갑/stale-chunk) → Slack 차단 (Sentry 태그만 부착)
  * non-crash (catch 가능한 일반 BE 에러) → Slack 차단 (Sentry 대시보드만)
  * production + crash + non-noise       → Slack 발송
- NODE_ENV 대신 NEXT_PUBLIC_VERCEL_ENV 사용 (Vercel preview 빌드도 NODE_ENV
  ='production' 으로 들어와 오염되던 문제 방지).
- Sentry events 자체는 그대로 전송 (대시보드 가시성 유지). Slack 만 게이트.

회귀 방지 (sentry.server.config.test.ts 신규):
- 정책 핵심 패턴 (isCrashEvent import, isProduction/isCrash/!isNoise 게이트, NEXT_PUBLIC_VERCEL_ENV 사용, classifyNoise 의 !isNoise 활용) 을 정적 검증.
- 5 cases PASS. beforeSend 가 Sentry.init 옵션 inline 이라 unit-level 호출 검증이 어려운 구조 → 소스 패턴 grep 으로 대체.

영향 범위:
- 사용자 화면 동작 변화 없음 (catch 처리되던 에러는 그대로 정상 fallback).
- 운영 Slack 노이즈 대폭 감소 (BE 5xx 누적 알림 차단).
- Sentry Issues 대시보드는 변화 없음 (전송 자체는 유지).

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->
