### PR TITLE
LC-3058 미션확인 단순화

### DIFF
--- a/apps/admin/src/api/attendance/attendance.ts
+++ b/apps/admin/src/api/attendance/attendance.ts
@@ -2,6 +2,7 @@ import axios from '@/utils/axios';
 import axiosV2 from '@/utils/axiosV2';
 import { useMutation } from '@tanstack/react-query';
 import {
+  BulkPatchAdminAttendanceReq,
   PatchAdminAttendanceReq,
   PatchAttendanceMentorReq,
   PatchAttendanceReq,
@@ -26,6 +27,16 @@ export const usePatchAttendanceMentor = () => {
       return axios.patch(`/attendance/${attendanceId}/mentor`, body);
     },
     onError: (error) => console.error('usePatchAttendanceMentor >>', error),
+  });
+};
+
+/** [어드민] 출석 일괄 확인여부 변경 PATCH /api/v2/admin/attendance/bulk */
+export const useBulkPatchAdminAttendance = () => {
+  return useMutation({
+    mutationFn: async (req: BulkPatchAdminAttendanceReq) => {
+      return axiosV2.patch('/admin/attendance/bulk', req);
+    },
+    onError: (error) => console.error('useBulkPatchAdminAttendance >>', error),
   });
 };
 

--- a/apps/admin/src/api/attendance/attendanceSchema.ts
+++ b/apps/admin/src/api/attendance/attendanceSchema.ts
@@ -36,6 +36,12 @@ export type PatchAdminAttendanceReq = {
   accountNum?: string;
 };
 
+/** [어드민] 출석 일괄 확인여부 변경 PATCH /api/v2/admin/attendance/bulk */
+export type BulkPatchAdminAttendanceReq = {
+  attendanceIdList: number[];
+  result: 'PASS' | 'WRONG' | 'FINAL_WRONG';
+};
+
 export const contentSchema = z.object({
   id: z.number(),
   title: z.string().nullish(),

--- a/apps/admin/src/domain/admin/challenge/submit-check-detail/table/table-body/TableRow.tsx
+++ b/apps/admin/src/domain/admin/challenge/submit-check-detail/table/table-body/TableRow.tsx
@@ -65,8 +65,11 @@ const TableRow = ({
   return (
     <div
       className={clsx('flex w-full', {
-        'bg-[#F1F1F1]': bgColor === 'DARK',
-        'bg-[#F7F7F7]': bgColor === 'LIGHT',
+        'bg-yellow-100': attendanceItem.attendance.result === 'WAITING',
+        'bg-[#F1F1F1]':
+          attendanceItem.attendance.result !== 'WAITING' && bgColor === 'DARK',
+        'bg-[#F7F7F7]':
+          attendanceItem.attendance.result !== 'WAITING' && bgColor === 'LIGHT',
       })}
     >
       <ChoiceCheckbox

--- a/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
+++ b/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
@@ -47,17 +47,22 @@ const ChallengeSubmitDetail = ({
 
   const handleConfirm = async () => {
     if (!pendingResult || isCheckedList.length === 0) return;
-    await bulkPatch.mutateAsync({
-      attendanceIdList: isCheckedList,
-      result: pendingResult,
-    });
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ['admin'] }),
-      queryClient.invalidateQueries({ queryKey: ['challenge'] }),
-    ]);
-    setIsCheckedList([]);
-    setPendingResult(null);
-    refetch();
+    try {
+      await bulkPatch.mutateAsync({
+        attendanceIdList: isCheckedList,
+        result: pendingResult,
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['admin'] }),
+        queryClient.invalidateQueries({ queryKey: ['challenge'] }),
+      ]);
+      setIsCheckedList([]);
+      refetch();
+    } catch (error) {
+      console.error('일괄 변경 실패:', error);
+    } finally {
+      setPendingResult(null);
+    }
   };
 
   return (
@@ -65,8 +70,9 @@ const ChallengeSubmitDetail = ({
       <div className="flex justify-end bg-[#F1F1F1] px-6 py-3">
         <select
           value={dropdownValue}
-          className="rounded-sm border border-gray-400 bg-transparent px-2 py-1 text-sm"
+          className="rounded-sm border border-gray-400 bg-transparent px-2 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           onChange={handleSelectChange}
+          disabled={isCheckedList.length === 0}
         >
           <option value="">확인여부 일괄변경</option>
           {BULK_RESULT_OPTIONS.map((result) => (

--- a/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
+++ b/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
@@ -1,11 +1,16 @@
+import { useBulkPatchAdminAttendance } from '@/api/attendance/attendance';
+import AlertModal from '@/common/alert/AlertModal';
 import { AttendanceItem, Mission } from '@/schema';
-import axios from '@/utils/axios';
-import { newMissionStatusToText } from '@/utils/convert';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { attendanceResultToText } from '@/utils/convert';
+import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import TableRow from '../../../submit-check-detail/table/table-body/TableRow';
 import TableHead from '../../../submit-check-detail/table/table-head/TableHead';
 import Button from '../../../ui/button/Button';
+
+type BulkResult = 'PASS' | 'WRONG' | 'FINAL_WRONG';
+
+const BULK_RESULT_OPTIONS: BulkResult[] = ['PASS', 'WRONG', 'FINAL_WRONG'];
 
 interface Props {
   mission: Mission;
@@ -15,54 +20,58 @@ interface Props {
 }
 
 const ChallengeSubmitDetail = ({
-  mission,
   setIsDetailShown,
   attendances,
   refetch,
 }: Props) => {
   const queryClient = useQueryClient();
 
-  const [isCheckedList, setIsCheckedList] = useState<Array<number>>([]);
+  const [isCheckedList, setIsCheckedList] = useState<number[]>([]);
   const [resultFilter, setResultFilter] = useState<
     AttendanceItem['attendance']['result'] | null
   >(null);
   const [statusFilter, setStatusFilter] = useState<
     AttendanceItem['attendance']['status'] | null
   >(null);
+  const [pendingResult, setPendingResult] = useState<BulkResult | null>(null);
+  const [dropdownValue, setDropdownValue] = useState('');
 
-  const editMissionStatus = useMutation({
-    mutationFn: async (status: string) => {
-      const res = await axios.patch(`/mission/${mission.id}`, {
-        status,
-        missionType: mission.missionType,
-      });
-      return res.data;
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ['mission'],
-      });
-    },
-  });
+  const bulkPatch = useBulkPatchAdminAttendance();
 
-  const handleChangeMissionStatus = async (
-    e: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
-    editMissionStatus.mutate(e.target.value);
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as BulkResult;
+    if (!value) return;
+    setPendingResult(value);
+    setDropdownValue('');
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingResult || isCheckedList.length === 0) return;
+    await bulkPatch.mutateAsync({
+      attendanceIdList: isCheckedList,
+      result: pendingResult,
+    });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['admin'] }),
+      queryClient.invalidateQueries({ queryKey: ['challenge'] }),
+    ]);
+    setIsCheckedList([]);
+    setPendingResult(null);
+    refetch();
   };
 
   return (
     <div className="w-full rounded">
       <div className="flex justify-end bg-[#F1F1F1] px-6 py-3">
         <select
-          name="missionStatusType"
-          id="missionStatusType"
+          value={dropdownValue}
           className="rounded-sm border border-gray-400 bg-transparent px-2 py-1 text-sm"
-          onChange={handleChangeMissionStatus}
+          onChange={handleSelectChange}
         >
-          {Object.keys(newMissionStatusToText).map((key) => (
-            <option key={key} value={key}>
-              {newMissionStatusToText[key]}
+          <option value="">확인여부 일괄변경</option>
+          {BULK_RESULT_OPTIONS.map((result) => (
+            <option key={result} value={result}>
+              {attendanceResultToText[result]}
             </option>
           ))}
         </select>
@@ -82,7 +91,6 @@ const ChallengeSubmitDetail = ({
             <TableRow
               key={item.attendance.id}
               attendanceItem={item}
-              missionDetail={mission}
               th={index + 1}
               bgColor={(index + 1) % 2 === 1 ? 'DARK' : 'LIGHT'}
               isChecked={isCheckedList.includes(item.attendance.id)}
@@ -95,6 +103,17 @@ const ChallengeSubmitDetail = ({
       <div className="mb-2 mt-4 flex justify-center">
         <Button onClick={() => setIsDetailShown(false)}>닫기</Button>
       </div>
+      {pendingResult && (
+        <AlertModal
+          title="확인여부 일괄변경"
+          onConfirm={handleConfirm}
+          onCancel={() => setPendingResult(null)}
+          disabled={bulkPatch.isPending}
+        >
+          선택한 {isCheckedList.length}명의 확인 여부를 &apos;
+          {attendanceResultToText[pendingResult]}&apos;로 변경하시겠습니까?
+        </AlertModal>
+      )}
     </div>
   );
 };

--- a/apps/admin/src/domain/admin/challenge/ui/lineTable/LineTableBodyRow.tsx
+++ b/apps/admin/src/domain/admin/challenge/ui/lineTable/LineTableBodyRow.tsx
@@ -1,9 +1,9 @@
+import AlertModal from '@/common/alert/AlertModal';
 import dayjs from '@/lib/dayjs';
 import { twMerge } from '@/lib/twMerge';
 import { TABLE_CONTENT, TABLE_STATUS } from '@/utils/convert';
 import React, { useState } from 'react';
 import { CiTrash } from 'react-icons/ci';
-import AlertModal from '@/common/alert/AlertModal';
 import DropdownCell from './DropdownCell';
 import LineTableBodyCell from './LineTableBodyCell';
 import TextareaCell from './TextareaCell';
@@ -123,7 +123,7 @@ const LineTableBodyRow = <T extends ItemWithStatus>({
     <div
       className={twMerge(
         'flex w-full gap-px rounded-md border p-1',
-        isEditMode ? 'border-neutral-500' : 'border-neutral-200',
+        isEditMode ? 'border-neutral-200' : 'border-neutral-500',
         onClick && 'cursor-pointer hover:bg-slate-50',
       )}
       onClick={() => onClick?.(values)}

--- a/apps/admin/src/pages/pages/challenge/ChallengeOperationAttendances.tsx
+++ b/apps/admin/src/pages/pages/challenge/ChallengeOperationAttendances.tsx
@@ -10,7 +10,7 @@ import LineTableBodyRow, {
 } from '@/domain/admin/challenge/ui/lineTable/LineTableBodyRow';
 import LineTableHead from '@/domain/admin/challenge/ui/lineTable/LineTableHead';
 import { Mission } from '@/schema';
-import { missionStatusToText, TABLE_CONTENT } from '@/utils/convert';
+import { TABLE_CONTENT } from '@/utils/convert';
 import React, { useMemo, useState } from 'react';
 
 type Row = Mission &
@@ -20,13 +20,13 @@ type Row = Mission &
 
 const cellWidthList = [
   'w-[140px]',
+  'w-[30%]',
+  'w-[300px]',
+  'w-[300px]',
   'w-[20%]',
-  'w-[200px]',
-  'w-[200px]',
-  'w-[20%]',
-  'w-[20%]',
+  'w-[15%]',
 ];
-const colNames = ['회차', '미션명', '공개일', '마감일', '제출현황', '상태'];
+const colNames = ['회차', '미션명', '공개일', '마감일', '제출현황', '확인여부'];
 
 const ChallengeOperationAttendances = () => {
   const { currentChallenge } = useAdminCurrentChallenge();
@@ -68,7 +68,7 @@ const ChallengeOperationAttendances = () => {
                   'startDate',
                   'endDate',
                   'currentAttendance',
-                  'missionStatusType',
+                  'waitingCount',
                 ]}
                 placeholders={colNames}
                 canEdits={[false, false, false, false, false, false]}
@@ -78,7 +78,14 @@ const ChallengeOperationAttendances = () => {
                   null,
                   null,
                   null,
-                  (status) => missionStatusToText[status],
+                  (count: number | null) =>
+                    count != null ? (
+                      <span className="font-bold text-red-500">
+                        확인중 {count}
+                      </span>
+                    ) : (
+                      '-'
+                    ),
                 ]}
                 contents={[
                   { type: TABLE_CONTENT.INPUT },

--- a/apps/admin/src/schema.ts
+++ b/apps/admin/src/schema.ts
@@ -926,6 +926,7 @@ export const missionAdmin = z
         attendanceCount: z.number(),
         lateAttendanceCount: z.number(),
         wrongAttendanceCount: z.number().optional().nullable(),
+        waitingCount: z.number().nullable(),
         applicationCount: z.number(),
         score: z.number(),
         lateScore: z.number(),


### PR DESCRIPTION
- waitingCount 필드 스키마 추가 및 확인여부 열에 대기 건수 표시 (null이면 -)
- 확인중 상태인 참여자 행 배경색 강조 (bg-yellow-100)
- 제출확인 상세 드롭다운을 확인완료/반려/최종반려 일괄변경으로 교체
- 선택한 참여자 확인여부 일괄변경 API(PATCH /api/v2/admin/attendance/bulk) 연동
- 변경 전 확인 팝업 노출 (선택한 N명의 확인 여부를 '상태'로 변경)

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3058]

[LC-3058]:https://letscareer-team.atlassian.net/browse/LC-3058


[LC-3058]: https://letscareer-team.atlassian.net/browse/LC-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3058]: https://letscareer-team.atlassian.net/browse/LC-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ