### PR TITLE
LC-3137 ADMIN 경험정리 미션 확인 버튼 미노출 버그 수정

### DIFF
--- a/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
+++ b/apps/admin/src/domain/admin/challenge/submit-check/table/table-body/ChallengeSubmitDetail.tsx
@@ -20,6 +20,7 @@ interface Props {
 }
 
 const ChallengeSubmitDetail = ({
+  mission,
   setIsDetailShown,
   attendances,
   refetch,
@@ -97,6 +98,7 @@ const ChallengeSubmitDetail = ({
             <TableRow
               key={item.attendance.id}
               attendanceItem={item}
+              missionDetail={mission}
               th={index + 1}
               bgColor={(index + 1) % 2 === 1 ? 'DARK' : 'LIGHT'}
               isChecked={isCheckedList.includes(item.attendance.id)}


### PR DESCRIPTION
- mission prop을 복구하여 TableRow에 missionDetail로 전달

## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3137]

[LC-3137]:https://letscareer-team.atlassian.net/browse/LC-3137


[LC-3137]: https://letscareer-team.atlassian.net/browse/LC-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3137]: https://letscareer-team.atlassian.net/browse/LC-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ