### PR TITLE
LC-3128 무료 자료집 인플루언서 전용 신청 수정

### DIFF
--- a/apps/admin/src/api/magnet/magnet.ts
+++ b/apps/admin/src/api/magnet/magnet.ts
@@ -113,6 +113,39 @@ export const usePatchMagnetVisibilityMutation = ({
   });
 };
 
+/** 접속 가능 여부(목록 노출과 독립) 토글 — 링크 접속·신청 게이트 */
+export const usePatchMagnetAccessibilityMutation = ({
+  successCallback,
+  errorCallback,
+}: {
+  successCallback?: () => void;
+  errorCallback?: () => void;
+} = {}) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      magnetId,
+      isAccessible,
+    }: {
+      magnetId: number;
+      isAccessible: boolean;
+    }) => {
+      const res = await axios.patch(`/admin/magnet/${magnetId}`, {
+        isAccessible,
+      });
+      return res.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: [magnetListQueryKey] });
+      successCallback?.();
+    },
+    onError: (error) => {
+      console.error(error);
+      errorCallback?.();
+    },
+  });
+};
+
 export const magnetDetailQueryOptions = (magnetId: number) => ({
   queryKey: [magnetDetailQueryKey, magnetId],
   queryFn: async (): Promise<MagnetDetailResponse> => {
@@ -147,6 +180,7 @@ export interface PatchMagnetReqBody {
   startDate?: string | null;
   endDate?: string | null;
   isVisible?: boolean;
+  isAccessible?: boolean;
   magnetQuestionList?: unknown[];
 }
 

--- a/apps/admin/src/api/magnet/magnetSchema.ts
+++ b/apps/admin/src/api/magnet/magnetSchema.ts
@@ -25,6 +25,11 @@ const magnetListItemSchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   isVisible: z.boolean(),
+  // 접속 가능 여부 — BE 백필 전(기존 행 NULL)에도 안전하도록 null/undefined → false.
+  isAccessible: z
+    .boolean()
+    .nullish()
+    .transform((v) => v ?? false),
   applicationCount: z.number(),
 });
 
@@ -57,6 +62,10 @@ const magnetInfoSchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   isVisible: z.boolean(),
+  isAccessible: z
+    .boolean()
+    .nullish()
+    .transform((v) => v ?? false),
 });
 
 const magnetQuestionSchema = z.object({

--- a/apps/admin/src/domain/admin/magnet/mock.ts
+++ b/apps/admin/src/domain/admin/magnet/mock.ts
@@ -11,6 +11,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-15T00:00:00',
     endDate: '2026-06-30T23:59:59',
     isVisible: false,
+    isAccessible: false,
     applicationCount: 9,
   },
   {
@@ -22,6 +23,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-10T00:00:00',
     endDate: '2026-07-31T23:59:59',
     isVisible: true,
+    isAccessible: true,
     applicationCount: 99,
   },
   {
@@ -33,6 +35,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-05T00:00:00',
     endDate: '2026-12-31T23:59:59',
     isVisible: true,
+    isAccessible: true,
     applicationCount: 999,
   },
   {
@@ -44,6 +47,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: null,
     endDate: null,
     isVisible: false,
+    isAccessible: false,
     applicationCount: 0,
   },
   {
@@ -55,6 +59,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: null,
     endDate: null,
     isVisible: false,
+    isAccessible: false,
     applicationCount: 0,
   },
 ];

--- a/apps/admin/src/domain/admin/magnet/types.ts
+++ b/apps/admin/src/domain/admin/magnet/types.ts
@@ -52,6 +52,7 @@ export interface MagnetListItem {
   startDate: string | null;
   endDate: string | null;
   isVisible: boolean;
+  isAccessible: boolean;
   applicationCount: number;
 }
 
@@ -108,6 +109,7 @@ export interface MagnetPostDetail {
   startDate: string | null;
   endDate: string | null;
   isVisible: boolean;
+  isAccessible: boolean;
 }
 
 // --- 마그넷 신청폼 관리 ---

--- a/apps/admin/src/pages/magnet/MagnetListPage.tsx
+++ b/apps/admin/src/pages/magnet/MagnetListPage.tsx
@@ -1,6 +1,7 @@
 import {
   useDeleteMagnetMutation,
   useGetMagnetListQuery,
+  usePatchMagnetAccessibilityMutation,
   usePatchMagnetVisibilityMutation,
 } from '@/api/magnet/magnet';
 import ActionButton from '@/domain/admin/ui/button/ActionButton';
@@ -24,6 +25,7 @@ const MagnetListPage = () => {
     useState<MagnetFilterValues>(INITIAL_FILTER);
   const { mutate: deleteMagnet } = useDeleteMagnetMutation();
   const { mutate: patchVisibility } = usePatchMagnetVisibilityMutation();
+  const { mutate: patchAccessibility } = usePatchMagnetAccessibilityMutation();
 
   // React Query로 마그넷 목록 조회 (타입/키워드 필터는 서버에서 처리)
   const { data: queryData } = useGetMagnetListQuery({
@@ -64,6 +66,13 @@ const MagnetListPage = () => {
       patchVisibility({ magnetId: id, isVisible });
     },
     [patchVisibility],
+  );
+
+  const handleToggleAccessibility = useCallback(
+    (id: number, isAccessible: boolean) => {
+      patchAccessibility({ magnetId: id, isAccessible });
+    },
+    [patchAccessibility],
   );
 
   const handleDelete = useCallback(
@@ -112,6 +121,7 @@ const MagnetListPage = () => {
           <MagnetTable
             data={data}
             onToggleVisibility={handleToggleVisibility}
+            onToggleAccessibility={handleToggleAccessibility}
             onDelete={handleDelete}
           />
         </main>

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -39,6 +39,7 @@ const buildDetailUrl = (magnetId: number, title: string) =>
 interface MagnetTableProps {
   data: MagnetListResponse;
   onToggleVisibility: (id: number, isVisible: boolean) => void;
+  onToggleAccessibility: (id: number, isAccessible: boolean) => void;
   onDelete: (id: number) => void;
 }
 
@@ -58,6 +59,7 @@ const magnetTypeOperators = createIncludesFilterOperators((props) => (
 const MagnetTable = ({
   data,
   onToggleVisibility,
+  onToggleAccessibility,
   onDelete,
 }: MagnetTableProps) => {
   const { snackbar } = useAdminSnackbar();
@@ -152,7 +154,7 @@ const MagnetTable = ({
       },
       {
         field: 'isVisible',
-        headerName: '노출여부',
+        headerName: '목록 노출',
         type: 'boolean',
         width: 90,
         renderCell: ({ row }) =>
@@ -161,6 +163,26 @@ const MagnetTable = ({
               checked={row.isVisible}
               onChange={(e) =>
                 onToggleVisibility(row.magnetId, e.target.checked)
+              }
+              size="small"
+            />
+          ) : (
+            '-'
+          ),
+      },
+      {
+        field: 'isAccessible',
+        headerName: '접속 가능',
+        description:
+          '목록에 안 떠도 링크로 접속·신청 가능. 노출 종료일이 지나면 자동 차단됩니다.',
+        type: 'boolean',
+        width: 90,
+        renderCell: ({ row }) =>
+          isMagnetVisibilityManageable(row.type) ? (
+            <Checkbox
+              checked={row.isAccessible}
+              onChange={(e) =>
+                onToggleAccessibility(row.magnetId, e.target.checked)
               }
               size="small"
             />
@@ -231,7 +253,7 @@ const MagnetTable = ({
         sortable: false,
         filterable: false,
         renderCell: ({ row }) =>
-          row.isVisible ? (
+          row.isAccessible ? (
             <Button
               variant="outlined"
               color="secondary"
@@ -251,7 +273,7 @@ const MagnetTable = ({
         sortable: false,
         filterable: false,
         renderCell: ({ row }) =>
-          row.isVisible ? (
+          row.isAccessible ? (
             <Button
               variant="outlined"
               color="secondary"
@@ -265,7 +287,13 @@ const MagnetTable = ({
           ),
       },
     ],
-    [onToggleVisibility, onDelete, handleCopyApplyLink, handleCopyDetailLink],
+    [
+      onToggleVisibility,
+      onToggleAccessibility,
+      onDelete,
+      handleCopyApplyLink,
+      handleCopyDetailLink,
+    ],
   );
 
   return (

--- a/apps/admin/src/pages/magnet/mock.ts
+++ b/apps/admin/src/pages/magnet/mock.ts
@@ -11,6 +11,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-15T00:00:00',
     endDate: '2026-06-30T23:59:59',
     isVisible: false,
+    isAccessible: false,
     applicationCount: 9,
   },
   {
@@ -22,6 +23,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-10T00:00:00',
     endDate: '2026-07-31T23:59:59',
     isVisible: true,
+    isAccessible: true,
     applicationCount: 99,
   },
   {
@@ -33,6 +35,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: '2026-01-05T00:00:00',
     endDate: '2026-12-31T23:59:59',
     isVisible: true,
+    isAccessible: true,
     applicationCount: 999,
   },
   {
@@ -44,6 +47,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: null,
     endDate: null,
     isVisible: false,
+    isAccessible: false,
     applicationCount: 0,
   },
   {
@@ -55,6 +59,7 @@ const MOCK_MAGNETS: MagnetListItem[] = [
     startDate: null,
     endDate: null,
     isVisible: false,
+    isAccessible: false,
     applicationCount: 0,
   },
 ];

--- a/apps/web/src/domain/library/apply/MagnetApplyContent.tsx
+++ b/apps/web/src/domain/library/apply/MagnetApplyContent.tsx
@@ -288,6 +288,16 @@ const MagnetApplyContent = ({
         if (status === 409) {
           mainAlreadyApplied = true;
           libraryApplyMainConflict({ magnetId, magnetType });
+        } else if (status === 403) {
+          // 접속 불가 또는 노출 기간 종료 — 예상된 비즈니스 차단(Sentry 미보고).
+          setResultModal({
+            isOpen: true,
+            title: '신청이 마감되었어요',
+            message: '신청 기간이 종료되었거나 접속할 수 없는 자료집이에요.',
+            variant: 'error',
+            shouldNavigate: true,
+          });
+          return;
         } else {
           libraryApplyUnexpectedError(mainError, {
             stage: 'main_submit',


### PR DESCRIPTION
## 개요
BE의 노출여부 2축 분리(목록 노출 `isVisible` / 접속 가능 `isAccessible`)에 맞춰 **어드민 토글**과 **웹 신청 차단 안내**를 연결합니다.

- 운영진이 `목록 노출 OFF + 접속 가능 ON`으로 설정 → 무료 자료집 목록엔 안 뜨지만 링크로 접속·신청 가능 (인플루언서 전용 페이지).
- 노출 종료일 이후엔 접속·신청 자동 차단(BE), 웹은 친절한 마감 안내.

> 연계 BE: Let-s-intern/lets-career-server#817 (머지·배포 + `UPDATE magnet SET is_accessible = is_visible WHERE is_accessible IS NULL;` 백필 필요)

## 변경

### 어드민
- `api/magnet/magnetSchema.ts`: 목록·상세 스키마에 `isAccessible` 추가 (BE 백필 전 null/undefined → false 변환으로 안전)
- `api/magnet/magnet.ts`: `PatchMagnetReqBody`에 `isAccessible`, **`usePatchMagnetAccessibilityMutation`** 추가
- `domain/admin/magnet/types.ts`: `MagnetListItem`/`MagnetPostDetail`에 `isAccessible`
- `pages/magnet/MagnetTable.tsx`: **"접속 가능" 체크박스 컬럼** 신설, "노출여부"→"목록 노출" 라벨 정리, **상세/신청 링크 복사 게이트를 `isVisible`→`isAccessible`로 변경** (목록 비노출이어도 링크 복사 가능)
- `pages/magnet/MagnetListPage.tsx`: 접속 가능 토글 핸들러 연결
- `*/magnet/mock.ts` ×2: 타입 정합용 `isAccessible` 추가

### 웹
- `domain/library/apply/MagnetApplyContent.tsx`: 신청 제출 **403(`MAGNET_NOT_ACCESSIBLE`)을 "신청이 마감되었어요" 모달**로 분기 (예상된 차단 → Sentry 미보고)

## 동작
| isVisible | isAccessible | 목록 | 링크 접속 | 신청 | 링크복사(어드민) |
|---|---|---|---|---|---|
| true | true | ✅ | ✅ | ✅ | ✅ |
| **false** | **true** | ❌ | ✅ | ✅ | **✅** | ← 인플루언서 |
| * | false / 기간만료 | - | ❌ | ❌(403→마감 안내) | ❌ |

## 검증
- prettier ✅ / eslint 0 errors(기존 경고 2건 무관) / typecheck: magnet·library 관련 **에러 0**
  - (admin typecheck에 남는 에러는 report·challenge-option·lexical 등 이 브랜치의 기존 무관 에러)

## 참고
- 노출/접속 토글은 기존과 동일하게 **목록 테이블에서만** 제어(글 등록/수정 폼엔 노출 토글이 원래 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [LC-3128]

[LC-3128]:https://letscareer-team.atlassian.net/browse/LC-3128


[LC-3128]: https://letscareer-team.atlassian.net/browse/LC-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ