### PR TITLE
feat(admin): 마그넷 목록 접속 상태 배지·링크 게이트

### DIFF
--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -8,7 +8,7 @@ import {
 import { useAdminSnackbar } from '@/hooks/useAdminSnackbar';
 import dayjs from '@/lib/dayjs';
 import { getLibraryPathname } from '@/utils/url';
-import { Button, Checkbox } from '@mui/material';
+import { Button, Checkbox, Chip } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { Link } from 'react-router-dom';
 import { useCallback, useMemo } from 'react';
@@ -35,6 +35,29 @@ const buildApplyUrl = (magnetId: number, type: MagnetTypeKey) => {
 
 const buildDetailUrl = (magnetId: number, title: string) =>
   `${WEB_URL}${getLibraryPathname({ id: magnetId, title })}`;
+
+// BE 접속 게이트와 동일: 접속 가능(isAccessible) AND 노출 종료일이 안 지남.
+// 종료일이 지나면 접속 가능을 켜놨어도 차단되므로 둘 다 만족해야 한다.
+const isMagnetExpired = (row: MagnetListItem) =>
+  !!row.endDate && dayjs(row.endDate).isBefore(dayjs());
+
+const isMagnetAccessibleNow = (row: MagnetListItem) =>
+  row.isAccessible && !isMagnetExpired(row);
+
+// 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다.
+// - 노출 중   : 목록에도 뜨고 링크도 됨 (목록노출 + 접속 + 기간 안)
+// - 링크 전용 : 목록엔 없지만 링크로 접속 가능 (인플루언서)
+// - 접속 차단 : 노출 기간 안이지만 접속 가능을 꺼서 막힘
+// - 만료      : 노출 종료일이 지나 접속·노출 모두 불가
+const getMagnetAccessState = (
+  row: MagnetListItem,
+): { label: string; color: 'success' | 'info' | 'warning' | 'default' } => {
+  if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
+  if (!row.isAccessible) return { label: '접속 차단', color: 'warning' };
+  return row.isVisible
+    ? { label: '노출 중', color: 'success' }
+    : { label: '링크 전용', color: 'info' };
+};
 
 interface MagnetTableProps {
   data: MagnetListResponse;
@@ -191,6 +214,20 @@ const MagnetTable = ({
           ),
       },
       {
+        field: 'accessStatus',
+        headerName: '접속 상태',
+        description:
+          '노출 중=목록+링크 / 링크 전용=링크로만(목록 비노출) / 접속 차단=기간 안인데 접속 꺼짐 / 만료=노출 종료일 지남.',
+        width: 110,
+        sortable: false,
+        filterable: false,
+        renderCell: ({ row }) => {
+          if (!isMagnetVisibilityManageable(row.type)) return '-';
+          const { label, color } = getMagnetAccessState(row);
+          return <Chip size="small" color={color} label={label} />;
+        },
+      },
+      {
         field: 'applicationCount',
         headerName: '신청자 수',
         width: 90,
@@ -253,7 +290,7 @@ const MagnetTable = ({
         sortable: false,
         filterable: false,
         renderCell: ({ row }) =>
-          row.isAccessible ? (
+          isMagnetAccessibleNow(row) ? (
             <Button
               variant="outlined"
               color="secondary"
@@ -273,7 +310,7 @@ const MagnetTable = ({
         sortable: false,
         filterable: false,
         renderCell: ({ row }) =>
-          row.isAccessible ? (
+          isMagnetAccessibleNow(row) ? (
             <Button
               variant="outlined"
               color="secondary"
@@ -302,6 +339,13 @@ const MagnetTable = ({
       rows={data.magnetList}
       columns={columns}
       getRowId={(row) => row.magnetId}
+      getRowClassName={(params) => {
+        const row = params.row as Row;
+        return isMagnetVisibilityManageable(row.type) &&
+          !isMagnetAccessibleNow(row)
+          ? 'magnet-row--inaccessible'
+          : '';
+      }}
       hideFooter
       getRowHeight={() => 'auto'}
       sx={{
@@ -312,6 +356,8 @@ const MagnetTable = ({
           whiteSpace: 'normal',
           wordBreak: 'break-word',
         },
+        // 접속 불가(만료·차단) 행은 회색 처리해 운영 중이 아님을 표시.
+        '& .magnet-row--inaccessible': { color: 'text.disabled' },
       }}
     />
   );


### PR DESCRIPTION
## 변경
어드민 마그넷 테이블에서 노출/접속 상태를 한눈에 이해하도록 정리.

**접속 상태 컬럼 추가** (4단계, 색으로 구분)
- 🟢 **노출 중** — 목록에도 뜨고 링크도 됨 (목록노출 + 접속 + 기간 안)
- 🔵 **링크 전용** — 목록엔 없지만 링크로 접속 가능 (인플루언서)
- 🟠 **접속 차단** — 노출 기간 안인데 접속 가능을 꺼서 막힘
- ⚪ **만료** — 노출 종료일이 지나 접속·노출 모두 불가

**링크 복사 버튼** — 실제 접속 가능(`isAccessible` AND 종료일 안 지남) 기준으로 노출. 기존엔 `isAccessible`만 봐서 만료된 건도 복사 버튼이 떴음.

**행 회색 처리** — 접속 불가(만료·차단) 행은 흐리게.

## 기준
BE 접속 게이트(접속 = `isAccessible` AND 종료일 ≥ 오늘)와 동일. 시작일은 현재 BE가 게이트하지 않으므로 "예정" 상태는 의도적으로 두지 않음(실제론 접속되는데 예정으로 표시되는 거짓 표시 방지).

## 검증
`npm run typecheck` — magnet 파일 에러 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)