### PR TITLE
feat(admin): 마그넷 접속 상태 배지 세분화 + 공개 예정일 정리

### DIFF
--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -41,32 +41,41 @@ const buildDetailUrl = (magnetId: number, title: string) =>
 const isMagnetExpired = (row: MagnetListItem) =>
   !!row.endDate && dayjs(row.endDate).isBefore(dayjs());
 
-// 출시알림(LAUNCH_ALERT)은 노출 종료일까지만 노출·구독되며 접속 가능 플래그는 안 본다.
-// (구독 신청 자체는 BE에서 종료 후에도 우회 허용되지만, 운영상 노출 기준으로 표시)
-// 그 외 타입은 접속 가능 + 노출 기간을 모두 만족해야 접속된다.
+// 노출 시작일 전 = 공개 예정 (웹에서 '공개예정'으로 잠겨 표시되는 기간).
+const isMagnetUpcoming = (row: MagnetListItem) =>
+  !!row.startDate && dayjs(row.startDate).isAfter(dayjs());
+
+// 지금 실제로 열려서 접근 가능한지(링크 복사·회색 판정 기준).
+// 출시알림(LAUNCH_ALERT)은 노출 종료일까지 구독 가능(접속 가능 플래그·시작일 무관).
+// 그 외 타입은 접속 가능 + 노출 기간(시작일~종료일) 안이어야 한다.
 const isMagnetAccessibleNow = (row: MagnetListItem) =>
   row.type === 'LAUNCH_ALERT'
     ? !isMagnetExpired(row)
-    : row.isAccessible && !isMagnetExpired(row);
+    : row.isAccessible && !isMagnetExpired(row) && !isMagnetUpcoming(row);
 
-// 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다.
-// - 구독 가능 : 출시알림(LAUNCH_ALERT) — 구독은 BE에서 항상 허용(노출/기간과 무관)
+// 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다. (웹 동작과 동일 기준)
+// - 구독 가능 : 출시알림(LAUNCH_ALERT) — 구독은 BE에서 항상 허용
+// - 만료      : 노출 종료일이 지나 접속·노출 모두 불가
+// - 접속 차단 : 접속 가능을 꺼서 어디에도 안 뜨고 링크도 막힘
+// - 공개 예정 : 노출 시작일 전 — 웹에서 '공개예정'으로 잠겨 표시(시작일에 공개)
 // - 노출 중   : 목록에도 뜨고 링크도 됨 (목록노출 + 접속 + 기간 안)
 // - 링크 전용 : 목록엔 없지만 링크로 접속 가능 (인플루언서)
-// - 접속 차단 : 노출 기간 안이지만 접속 가능을 꺼서 막힘
-// - 만료      : 노출 종료일이 지나 접속·노출 모두 불가
 const getMagnetAccessState = (
   row: MagnetListItem,
-): { label: string; color: 'success' | 'info' | 'warning' | 'default' } => {
+): {
+  label: string;
+  color: 'success' | 'info' | 'warning' | 'default' | 'secondary';
+} => {
   if (row.type === 'LAUNCH_ALERT')
     return isMagnetExpired(row)
       ? { label: '만료', color: 'default' }
       : { label: '구독 가능', color: 'info' };
   if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
   if (!row.isAccessible) return { label: '접속 차단', color: 'warning' };
+  if (isMagnetUpcoming(row)) return { label: '공개 예정', color: 'info' };
   return row.isVisible
     ? { label: '노출 중', color: 'success' }
-    : { label: '링크 전용', color: 'info' };
+    : { label: '링크 전용', color: 'secondary' };
 };
 
 interface MagnetTableProps {
@@ -165,13 +174,13 @@ const MagnetTable = ({
       },
       {
         field: 'startDate',
-        headerName: '출시 알림 전송일',
+        headerName: '공개 예정일',
         description:
-          '출시알림(LAUNCH_ALERT) 구독자에게 알림을 보내는 날짜. 다른 타입에서는 사용하지 않습니다.',
+          '이 날짜 전에는 웹에서 "공개예정"으로 잠겨 표시되고, 이 날짜부터 공개됩니다. 출시알림은 이 날짜에 구독자에게 알림이 발송됩니다.',
         type: 'dateTime',
         width: 130,
         valueGetter: (_, row) =>
-          row.type === 'LAUNCH_ALERT' && row.startDate
+          isMagnetVisibilityManageable(row.type) && row.startDate
             ? dayjs(row.startDate).toDate()
             : null,
         valueFormatter: (value) => formatDateTimeCellValue(value),

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -53,29 +53,36 @@ const isMagnetAccessibleNow = (row: MagnetListItem) =>
     ? !isMagnetExpired(row)
     : row.isAccessible && !isMagnetExpired(row) && !isMagnetUpcoming(row);
 
-// 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다. (웹 동작과 동일 기준)
-// - 구독 가능 : 출시알림(LAUNCH_ALERT) — 구독은 BE에서 항상 허용
-// - 만료      : 노출 종료일이 지나 접속·노출 모두 불가
-// - 접속 차단 : 접속 가능을 꺼서 어디에도 안 뜨고 링크도 막힘
-// - 공개 예정 : 노출 시작일 전 — 웹에서 '공개예정'으로 잠겨 표시(시작일에 공개)
-// - 노출 중   : 목록에도 뜨고 링크도 됨 (목록노출 + 접속 + 기간 안)
-// - 링크 전용 : 목록엔 없지만 링크로 접속 가능 (인플루언서)
+// 어드민이 한눈에 이해할 수 있게 상태를 세분화한다. (웹 동작과 동일 기준)
+// [일반 타입]
+// - 만료       : 노출 종료일이 지나 접속·노출 모두 불가
+// - 접속 차단  : 접속 가능을 꺼서 어디에도 안 뜨고 링크도 막힘
+// - 공개 예정  : 시작일 전 + 목록노출 ON — 시작일에 목록·링크로 공개 예정
+// - 예약·미노출: 시작일 전 + 목록노출 OFF — 시작일에 링크로만 열림(목록엔 안 뜸)
+// - 노출 중    : 진행 중 + 목록노출 ON — 목록에도 뜨고 링크도 됨
+// - 링크 전용  : 진행 중 + 목록노출 OFF — 목록엔 없고 링크로만(인플루언서)
+// [출시알림] 구독은 BE에서 항상 허용 — 발송일(시작일) 기준으로만 구분
+// - 출시 예정  : 발송일 전(구독 받는 중) · 구독 가능 : 발송일~종료일 · 만료 : 종료 후
 const getMagnetAccessState = (
   row: MagnetListItem,
 ): {
   label: string;
-  color: 'success' | 'info' | 'warning' | 'default' | 'secondary';
+  color: 'success' | 'info' | 'warning' | 'default' | 'secondary' | 'primary';
 } => {
-  if (row.type === 'LAUNCH_ALERT')
-    return isMagnetExpired(row)
-      ? { label: '만료', color: 'default' }
-      : { label: '구독 가능', color: 'info' };
+  if (row.type === 'LAUNCH_ALERT') {
+    if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
+    if (isMagnetUpcoming(row)) return { label: '출시 예정', color: 'primary' };
+    return { label: '구독 가능', color: 'info' };
+  }
   if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
   if (!row.isAccessible) return { label: '접속 차단', color: 'warning' };
-  if (isMagnetUpcoming(row)) return { label: '공개 예정', color: 'info' };
+  if (isMagnetUpcoming(row))
+    return row.isVisible
+      ? { label: '공개 예정', color: 'primary' }
+      : { label: '예약·미노출', color: 'secondary' };
   return row.isVisible
     ? { label: '노출 중', color: 'success' }
-    : { label: '링크 전용', color: 'secondary' };
+    : { label: '링크 전용', color: 'info' };
 };
 
 interface MagnetTableProps {

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -156,10 +156,12 @@ const MagnetTable = ({
       {
         field: 'startDate',
         headerName: '출시 알림 전송일',
+        description:
+          '출시알림(LAUNCH_ALERT) 구독자에게 알림을 보내는 날짜. 다른 타입에서는 사용하지 않습니다.',
         type: 'dateTime',
         width: 130,
         valueGetter: (_, row) =>
-          isMagnetVisibilityManageable(row.type) && row.startDate
+          row.type === 'LAUNCH_ALERT' && row.startDate
             ? dayjs(row.startDate).toDate()
             : null,
         valueFormatter: (value) => formatDateTimeCellValue(value),

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -41,10 +41,13 @@ const buildDetailUrl = (magnetId: number, title: string) =>
 const isMagnetExpired = (row: MagnetListItem) =>
   !!row.endDate && dayjs(row.endDate).isBefore(dayjs());
 
-// 출시알림(LAUNCH_ALERT)은 BE에서 구독(신청) 게이트를 우회해 항상 신청 가능하다.
+// 출시알림(LAUNCH_ALERT)은 노출 종료일까지만 노출·구독되며 접속 가능 플래그는 안 본다.
+// (구독 신청 자체는 BE에서 종료 후에도 우회 허용되지만, 운영상 노출 기준으로 표시)
 // 그 외 타입은 접속 가능 + 노출 기간을 모두 만족해야 접속된다.
 const isMagnetAccessibleNow = (row: MagnetListItem) =>
-  row.type === 'LAUNCH_ALERT' || (row.isAccessible && !isMagnetExpired(row));
+  row.type === 'LAUNCH_ALERT'
+    ? !isMagnetExpired(row)
+    : row.isAccessible && !isMagnetExpired(row);
 
 // 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다.
 // - 구독 가능 : 출시알림(LAUNCH_ALERT) — 구독은 BE에서 항상 허용(노출/기간과 무관)
@@ -55,7 +58,10 @@ const isMagnetAccessibleNow = (row: MagnetListItem) =>
 const getMagnetAccessState = (
   row: MagnetListItem,
 ): { label: string; color: 'success' | 'info' | 'warning' | 'default' } => {
-  if (row.type === 'LAUNCH_ALERT') return { label: '구독 가능', color: 'info' };
+  if (row.type === 'LAUNCH_ALERT')
+    return isMagnetExpired(row)
+      ? { label: '만료', color: 'default' }
+      : { label: '구독 가능', color: 'info' };
   if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
   if (!row.isAccessible) return { label: '접속 차단', color: 'warning' };
   return row.isVisible

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -155,7 +155,7 @@ const MagnetTable = ({
       },
       {
         field: 'startDate',
-        headerName: '노출 시작일',
+        headerName: '출시 알림 전송일',
         type: 'dateTime',
         width: 130,
         valueGetter: (_, row) =>

--- a/apps/admin/src/pages/magnet/MagnetTable.tsx
+++ b/apps/admin/src/pages/magnet/MagnetTable.tsx
@@ -41,10 +41,13 @@ const buildDetailUrl = (magnetId: number, title: string) =>
 const isMagnetExpired = (row: MagnetListItem) =>
   !!row.endDate && dayjs(row.endDate).isBefore(dayjs());
 
+// 출시알림(LAUNCH_ALERT)은 BE에서 구독(신청) 게이트를 우회해 항상 신청 가능하다.
+// 그 외 타입은 접속 가능 + 노출 기간을 모두 만족해야 접속된다.
 const isMagnetAccessibleNow = (row: MagnetListItem) =>
-  row.isAccessible && !isMagnetExpired(row);
+  row.type === 'LAUNCH_ALERT' || (row.isAccessible && !isMagnetExpired(row));
 
 // 어드민이 한눈에 이해할 수 있는 직관적 상태로 묶는다.
+// - 구독 가능 : 출시알림(LAUNCH_ALERT) — 구독은 BE에서 항상 허용(노출/기간과 무관)
 // - 노출 중   : 목록에도 뜨고 링크도 됨 (목록노출 + 접속 + 기간 안)
 // - 링크 전용 : 목록엔 없지만 링크로 접속 가능 (인플루언서)
 // - 접속 차단 : 노출 기간 안이지만 접속 가능을 꺼서 막힘
@@ -52,6 +55,7 @@ const isMagnetAccessibleNow = (row: MagnetListItem) =>
 const getMagnetAccessState = (
   row: MagnetListItem,
 ): { label: string; color: 'success' | 'info' | 'warning' | 'default' } => {
+  if (row.type === 'LAUNCH_ALERT') return { label: '구독 가능', color: 'info' };
   if (isMagnetExpired(row)) return { label: '만료', color: 'default' };
   if (!row.isAccessible) return { label: '접속 차단', color: 'warning' };
   return row.isVisible


### PR DESCRIPTION
> #2405에서 초기 배지 작업만 머지된 뒤, 웹 실제 동작을 재확인하며 정리·세분화한 후속 변경입니다.

## 배경
`startDate(노출 시작일)`가 실제로는 **웹에서 모든 타입의 "공개예정"(시작일 전 잠금 표시)을 제어**하는 핵심 값임을 확인 (`LibraryListContent`·`LibraryArticle`의 `isUpcoming`). 초기에 이를 "출시알림 전용"으로 오판해 컬럼을 숨겼던 것을 바로잡고, 상태 배지를 웹 동작에 맞춰 세분화.

## 변경
**컬럼**
- `노출 시작일` → **`공개 예정일`** (전 타입 표시). "이 날짜 전엔 웹에서 공개예정 잠금, 이 날짜부터 공개. 출시알림은 이 날짜에 알림 발송."

**접속 상태 배지 — 세분화 (웹 동작과 동일 기준)**
- 일반 타입: `만료` / `접속 차단` / `공개 예정`(시작전·노출ON) / `예약·미노출`(시작전·노출OFF) / `노출 중` / `링크 전용`
- 출시알림(LAUNCH_ALERT): `출시 예정`(발송 전) / `구독 가능`(발송~종료) / `만료` — 구독은 BE에서 항상 허용되는 특성 반영

**링크 복사 / 행 회색**
- 실제 접속 가능(접속 ON + 노출 기간 안)일 때만 링크 복사 노출, 그 외 회색 처리
- 출시알림은 종료일까지 구독 가능으로 일치

## 검증
- `tsc --noEmit` magnet 에러 없음 / `eslint` 통과 / `prettier` 정리됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)