### PR TITLE
LC-3134 하반기 멤버십 랜딩페이지 프로토 타입 배포

### DIFF
--- a/apps/web/src/common/layout/header/GlobalNavTopBar.tsx
+++ b/apps/web/src/common/layout/header/GlobalNavTopBar.tsx
@@ -11,6 +11,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import GlobalNavItem from './GlobalNavItem';
 import LoginLink from './LoginLink';
 import LogoLink from './LogoLink';
+import MembershipNavLabel from './MembershipNavLabel';
 import SignUpLink from './SignUpLink';
 import { SubNavItemProps } from './SubNavItem';
 
@@ -81,12 +82,23 @@ function GlobalNavTopBar({ loginRedirect, toggleMenu, isLoginPage }: Props) {
         <GlobalNavItem
           className={twMerge(
             'mr-6 hidden h-9 items-center border-b-[1.5px] border-transparent md:flex',
+            pathname.startsWith('/membership') && 'border-neutral-0',
+          )}
+          href="/membership"
+          isNew
+        >
+          <MembershipNavLabel />
+        </GlobalNavItem>
+        {/* 메뉴 정리: 멤버십 출시 메뉴 추가로 상단바가 혼잡해 잠시 숨김 (모바일 드로어에는 유지) */}
+        {/* <GlobalNavItem
+          className={twMerge(
+            'mr-6 hidden h-9 items-center border-b-[1.5px] border-transparent md:flex',
             pathname === '/about' && 'border-neutral-0',
           )}
           href="/about"
         >
           렛츠커리어 스토리
-        </GlobalNavItem>
+        </GlobalNavItem> */}
         <GlobalNavItem
           className={twMerge(
             'b2b_landing_click mr-6 hidden h-9 items-center border-b-[1.5px] border-transparent md:flex',

--- a/apps/web/src/common/layout/header/MembershipNavLabel.tsx
+++ b/apps/web/src/common/layout/header/MembershipNavLabel.tsx
@@ -1,0 +1,36 @@
+import { twMerge } from '@/lib/twMerge';
+
+/** 4각 반짝이(✦) 아이콘. 위치/크기는 className, 깜빡임 타이밍은 delay로 분산. */
+function Sparkle({ className, delay }: { className: string; delay: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      style={{ animationDelay: delay }}
+      className={twMerge('membership-sparkle absolute', className)}
+    >
+      <path
+        d="M12 0c0 6.6-5.4 12-12 12 6.6 0 12 5.4 12 12 0-6.6 5.4-12 12-12-6.6 0-12-5.4-12-12Z"
+        fill="#4D55F5"
+      />
+    </svg>
+  );
+}
+
+/**
+ * "2026 하반기 멤버십 출시" 네비 메뉴 라벨.
+ * 좌상단에 크기가 다른 반짝이 3개(✦ twinkle) + 글자 샤인 스윕을 입혀 신규/출시 메뉴를 강조한다.
+ * 데스크톱 상단바(GlobalNavTopBar)와 모바일 드로어(SideNavItem) 두 곳에서 공용.
+ */
+function MembershipNavLabel({ className }: { className?: string }) {
+  return (
+    <span className={twMerge('relative inline-flex items-center', className)}>
+      <Sparkle className="-left-3 -top-2.5 h-3 w-3" delay="0s" />
+      <Sparkle className="-left-0.5 -top-2 h-2 w-2" delay="0.5s" />
+      <Sparkle className="-top-2.5 left-1 h-1.5 w-1.5" delay="1s" />
+      <span className="membership-shine">2026 하반기 멤버십 출시</span>
+    </span>
+  );
+}
+
+export default MembershipNavLabel;

--- a/apps/web/src/common/layout/header/NavBar.tsx
+++ b/apps/web/src/common/layout/header/NavBar.tsx
@@ -19,6 +19,7 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import ExternalNavList from './ExternalNavList';
 import GlobalNavItem from './GlobalNavItem';
 import GlobalNavTopBar from './GlobalNavTopBar';
+import MembershipNavLabel from './MembershipNavLabel';
 import NavOverlay from './NavOverlay';
 import SideNavContainer from './SideNavContainer';
 import SideNavItem from './SideNavItem';
@@ -247,6 +248,9 @@ const NavBar = ({ isLoginPage, disableFixed, ...props }: NavBarProps) => {
 
       {/* 사이드 네비게이션 바 */}
       <SideNavContainer isOpen={isOpen} onClose={closeMenu}>
+        <SideNavItem href="/membership" isNew>
+          <MembershipNavLabel />
+        </SideNavItem>
         <SideNavItem href="/mypage/career/board">마이페이지</SideNavItem>
         <SideNavItem href="/community">
           커뮤니티

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -324,7 +324,7 @@ input[type='number'] {
 /* Swiper */
 .swiper-button-prev,
 .swiper-button-next {
-  @apply hidden h-10 w-10 items-center justify-center rounded-full border border-neutral-80 bg-white/75 md:flex !important;
+  @apply border-neutral-80 hidden h-10 w-10 items-center justify-center rounded-full border bg-white/75 md:flex !important;
 }
 
 .swiper-button-prev::after,
@@ -372,6 +372,57 @@ input[type='number'] {
 .speech-bubble {
   position: relative;
   border-radius: 0.4em;
+}
+
+/* 멤버십 네비 메뉴 강조: 글자 샤인 스윕 + 좌상단 반짝이(MembershipNavLabel) */
+.membership-shine {
+  background: linear-gradient(
+    100deg,
+    #27272d 0%,
+    #27272d 42%,
+    #4d55f5 50%,
+    #27272d 58%,
+    #27272d 100%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: membership-shine 5s linear infinite;
+}
+
+@keyframes membership-shine {
+  0% {
+    background-position: 130% 0;
+  }
+  100% {
+    background-position: -130% 0;
+  }
+}
+
+.membership-sparkle {
+  transform-origin: center;
+  animation: membership-sparkle 1.8s ease-in-out infinite;
+}
+
+@keyframes membership-sparkle {
+  0%,
+  100% {
+    transform: scale(0.7) rotate(0deg);
+    opacity: 0.45;
+  }
+  50% {
+    transform: scale(1.1) rotate(15deg);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .membership-shine,
+  .membership-sparkle {
+    animation: none;
+  }
 }
 
 .speech-bubble:after {


### PR DESCRIPTION
## 요약

헤더에 새 멤버십 랜딩(`/membership`) 진입 메뉴를 추가하고, 신규/출시 메뉴임을 강조하는 모션을 입혔습니다.

## 변경 사항

- **멤버십 출시 메뉴 추가**: 데스크톱 상단바(`GlobalNavTopBar`)·모바일 드로어(`NavBar`)에 "2026 하반기 멤버십 출시" 메뉴 추가 → `/membership` 연결, 기존 빨간 `N` 배지 유지
- **`MembershipNavLabel` 공용 컴포넌트 신설**: 두 위치에서 재사용. 글자 좌상단에 크기가 다른 반짝이(✦) 3개가 타이밍을 어긋나게 twinkle + 파란색 샤인 스윕(5s 주기)이 글자 위를 지나감. `prefers-reduced-motion` 시 애니메이션 정지
- **"렛츠커리어 스토리" 데스크톱 상단바 잠시 숨김**: 멤버십 메뉴 추가로 상단바가 혼잡해져 임시 주석 처리(복구 용이). 모바일 드로어에는 유지

## 구현 메모

- 샤인은 `background-clip: text` + 이동하는 linear-gradient로 구현(JS 없음, GPU 친화)
- 애니메이션은 Tailwind 유틸이 아닌 `index.css` 순수 CSS 클래스로 정의 → JIT purge 영향 없음

## 검증

- `tsc --noEmit`(web) ✅ / ESLint ✅ / Prettier ✅
- 데스크톱·모바일 헤더에서 메뉴 노출 및 `/membership` 이동 확인

> 스크린샷/모션은 리뷰 시 첨부 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [LC-3134]

[LC-3134]:https://letscareer-team.atlassian.net/browse/LC-3134


[LC-3134]: https://letscareer-team.atlassian.net/browse/LC-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3134]: https://letscareer-team.atlassian.net/browse/LC-3134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ