### PR TITLE
fix(admin): 챌린지 플랜명 입력 길이 제한 6 → 16자 상향

### DIFF
--- a/apps/admin/src/domain/admin/program/challenge/ChallengePrice.tsx
+++ b/apps/admin/src/domain/admin/program/challenge/ChallengePrice.tsx
@@ -267,7 +267,7 @@ export default function ChallengePrice<
             name="title"
             size="small"
             placeholder="라이트 플랜명을 입력해주세요"
-            maxLength={6}
+            maxLength={16}
             value={lightInfo.title}
             onChange={onChangeLightInfo}
           />
@@ -413,7 +413,7 @@ export default function ChallengePrice<
         name="title"
         size="small"
         placeholder="베이직 플랜명을 입력해주세요"
-        maxLength={6}
+        maxLength={16}
         value={basicInfo.title}
         onChange={(e) => onChangePricePlanInfo('BASIC', e)}
       />
@@ -457,7 +457,7 @@ export default function ChallengePrice<
             size="small"
             placeholder="스탠다드 플랜명을 입력해주세요"
             value={standardInfo.title}
-            maxLength={6}
+            maxLength={16}
             onChange={(e) => onChangePricePlanInfo('STANDARD', e)}
           />
           <OutlinedTextarea
@@ -501,7 +501,7 @@ export default function ChallengePrice<
             size="small"
             placeholder="프리미엄 플랜명을 입력해주세요"
             value={premiumInfo.title}
-            maxLength={6}
+            maxLength={16}
             onChange={(e) => onChangePricePlanInfo('PREMIUM', e)}
           />
           <OutlinedTextarea


### PR DESCRIPTION
## 요약

어드민 챌린지 개설/편집(`/challenge/{id}/edit`)의 가격 플랜명(라이트/베이직/스탠다드/프리미엄) 입력이 `maxLength={6}`으로 막혀 6자를 넘는 플랜명을 못 넣던 문제를 해결합니다. FE `maxLength`만 16으로 상향.

## 배경 / 검증

- **백엔드 제한 없음**: `ChallengePrice.title`은 `@Column(length)`·`@Size` 없는 `String` → DB 기본 `VARCHAR(255)`. price 도메인 전체에 길이 검증 0건. 6자 제한은 순수 FE `maxLength` 단독이었음.
- **유저 화면 길이에 견고**:
  - 플랜 탭(`ChallengePriceInfoContent` `PlanButton`) = `truncate text-nowrap` → 길어도 말줄임, 안 깨짐
  - 플랜 카드(`ChallengePricePlanSection` `PricePlanCard`, `w-72`) = truncate 없이 자동 줄바꿈, 높이 auto
  - 가격 리스트/마케팅 카드도 줄바꿈 → 구조 파손 없음
- 16자면 대부분 한 줄, 좁은 카드에서 최대 2줄 줄바꿈(허용). 탭은 우아하게 말줄임.

## 변경

`apps/admin/src/domain/admin/program/challenge/ChallengePrice.tsx` — 플랜명 입력 4곳 `maxLength={6}` → `maxLength={16}`

## 검증

- ESLint ✅ / Prettier ✅ / `tsc`(해당 파일) ✅
- 어드민 편집 화면에서 16자 입력 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)