### PR TITLE
fix(membership): 멤버십 위임 챌린지 결제 시 쿠폰 입력 차단

### DIFF
--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -6,6 +6,7 @@ import CreditCardIcon from '@/assets/icons/credit-card.svg?react';
 import { Duration } from '@/common/Duration';
 import BackHeader from '@/common/header/BackHeader';
 import LoadingContainer from '@/common/loading/LoadingContainer';
+import { MEMBERSHIP_CHALLENGE_ID } from '@/domain/membership/lib/membershipChallenge';
 import { COUPON_DISABLED_CHALLENGE_TYPES } from '@/domain/program/program-detail/apply/constants';
 import CouponSection, {
   CouponSectionProps,
@@ -103,7 +104,13 @@ const PaymentInputContent = () => {
   })();
   const isCouponDisabledType =
     COUPON_DISABLED_CHALLENGE_TYPES.includes(challengeType);
-  const showCouponSection = !isCouponDisabledType || hasB2BParam;
+  // 하반기 멤버십(위임 챌린지)은 별도 플랜가로 판매되어 쿠폰 입력을 막는다.
+  // TODO: 멤버십 프로모션 종료 후 이 분기(isMembership)와 위 import를 삭제할 것.
+  const isMembership =
+    programApplicationData.programType === 'challenge' &&
+    programApplicationData.programId === MEMBERSHIP_CHALLENGE_ID;
+  const showCouponSection =
+    (!isCouponDisabledType || hasB2BParam) && !isMembership;
 
   const setUserInfo = useCallback((info: UserInfo) => {
     const { contactEmail, email, name, phoneNumber, question } = info;


### PR DESCRIPTION
## 요약

멤버십(하반기) 위임 챌린지로 결제 진입 시 **쿠폰 입력 섹션을 숨긴다**.

멤버십은 별도 플랜가로 판매되므로 추가 쿠폰 할인이 적용되면 안 된다. 결제 입력 페이지(`payment-input`)에서 `programType === 'challenge' && programId === MEMBERSHIP_CHALLENGE_ID` 인 경우 `showCouponSection` 을 `false` 로 강제한다.

## 변경 사항

- `apps/web/src/app/(user)/payment-input/page.tsx`
  - `isMembership` 분기 추가 → `showCouponSection` 에 `&& !isMembership` 결합
  - `MEMBERSHIP_CHALLENGE_ID` import 추가
  - 프로모션 종료 후 제거할 임시 분기임을 `TODO` 주석으로 명시

## 검증

- ✅ `pnpm typecheck:web`
- ✅ `pnpm lint:web` (신규 경고 없음)
- ✅ prettier 포맷 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)