### PR TITLE
feat(mypage): 멤버십 카드 '가이드 확인' 버튼 → 노션 가이드 새 탭

### DIFF
--- a/apps/web/src/domain/membership/lib/membershipChallenge.ts
+++ b/apps/web/src/domain/membership/lib/membershipChallenge.ts
@@ -20,6 +20,18 @@ export function isMembershipChallengeConfigured(): boolean {
   return isValidMembershipChallengeId(MEMBERSHIP_CHALLENGE_ID);
 }
 
+/** 하반기 멤버십 안내 가이드(노션). 마이페이지 "가이드 확인" 버튼이 새 탭으로 연다. */
+export const MEMBERSHIP_GUIDE_URL =
+  'https://letsintern.notion.site/2026-38f5e77cbee180d7a77deab36a8ed88b';
+
+/** 주어진 programId 가 멤버십 위임 챌린지인지. env 미설정이면 항상 false. */
+export function isMembershipChallengeProgram(programId: number): boolean {
+  return (
+    isValidMembershipChallengeId(MEMBERSHIP_CHALLENGE_ID) &&
+    programId === MEMBERSHIP_CHALLENGE_ID
+  );
+}
+
 /**
  * 멤버십이 출시(결제 가능)된 상태인지 — 빌드 타임 env 로 결정되는 상수.
  * false 면(=env 미설정) CTA 를 "출시 전" 비활성 상태로 표시한다.

--- a/apps/web/src/domain/mypage/application/utils/applicationCardConfig.ts
+++ b/apps/web/src/domain/mypage/application/utils/applicationCardConfig.ts
@@ -1,5 +1,9 @@
 import type { ApplicationDownloadType } from '@/api/application';
 import { MypageApplication } from '@/api/application';
+import {
+  isMembershipChallengeProgram,
+  MEMBERSHIP_GUIDE_URL,
+} from '@/domain/membership/lib/membershipChallenge';
 import { getReportThumbnail } from '@/domain/mypage/credit/ui/CreditListItem';
 import dayjs from '@/lib/dayjs';
 import {
@@ -28,6 +32,7 @@ export interface MypageApplicationCardConfig {
     label: string;
     disabled?: boolean;
     href?: string;
+    external?: boolean;
     onClick?: () => void;
     confirm?: {
       title: string;
@@ -102,14 +107,23 @@ const toProgramCardConfig = (
     pricePlanType !== 'LIGHT' && programStartDate?.isBefore(dayjs());
   const isDashboardVisible = isChallenge ? isChallengeDashboardVisible : isLive;
 
+  const isMembership =
+    isChallenge && isMembershipChallengeProgram(programId ?? 0);
+
   const actionButton =
     isDashboardVisible && programType && programId != null && id != null
-      ? {
-          label: isChallenge ? '대시보드 입장' : '클래스 입장',
-          href: isChallenge
-            ? `/challenge/${id}/${programId}`
-            : `/program/live/${programId}`,
-        }
+      ? isMembership
+        ? {
+            label: '가이드 확인',
+            href: MEMBERSHIP_GUIDE_URL,
+            external: true,
+          }
+        : {
+            label: isChallenge ? '대시보드 입장' : '클래스 입장',
+            href: isChallenge
+              ? `/challenge/${id}/${programId}`
+              : `/program/live/${programId}`,
+          }
       : undefined;
 
   return {

--- a/apps/web/src/domain/mypage/ui/card/NewApplicationCard.tsx
+++ b/apps/web/src/domain/mypage/ui/card/NewApplicationCard.tsx
@@ -58,6 +58,10 @@ export const MypageApplicationCard = ({
     }
 
     if (actionButton.href) {
+      if (actionButton.external) {
+        window.open(actionButton.href, '_blank', 'noopener,noreferrer');
+        return;
+      }
       router.push(actionButton.href);
       return;
     }


### PR DESCRIPTION
## 요약

하반기 멤버십 구매자의 마이페이지 신청 카드에서, 버튼을 **대시보드 입장 → 가이드 확인**으로 바꾸고 클릭 시 안내 노션 페이지를 **새 탭**으로 엽니다. 일반 챌린지 카드의 동작은 그대로 유지합니다.

## 배경

멤버십은 별도 `programType`이 아니라 어드민이 만든 챌린지 1개(`NEXT_PUBLIC_MEMBERSHIP_CHALLENGE_ID`)에 위임돼 있어, 마이페이지에는 일반 `CHALLENGE` 카드로 렌더됩니다. 따라서 다른 챌린지처럼 "대시보드 입장" 버튼이 떠서 개인 대시보드로 이동합니다. 멤버십은 대시보드 대신 안내 가이드로 연결돼야 합니다.

- 노션 가이드: `https://letsintern.notion.site/2026-38f5e77cbee180d7a77deab36a8ed88b`
- 멤버십 판별: `programId === MEMBERSHIP_CHALLENGE_ID` (결제 플로우 `payment-input`과 동일 규칙 재사용)
- env 미설정 시 `NaN` 비교라 항상 기존 "대시보드 입장"으로 안전 폴백

## 변경 사항

- `membershipChallenge.ts`: `MEMBERSHIP_GUIDE_URL` 상수 + `isMembershipChallengeProgram()` 헬퍼 추가 (기존 `isValidMembershipChallengeId` 재사용)
- `applicationCardConfig.ts`: `actionButton.external` 필드 추가, 멤버십이면 라벨/URL/external 분기
- `NewApplicationCard.tsx`: `external` 링크는 `window.open(_blank, noopener,noreferrer)`로 새 탭 처리
- 노출 조건(시작일 지남·非LIGHT)과 일반 챌린지 동작은 손대지 않음

## 검증

- `pnpm --filter web typecheck` 통과, ESLint 0 에러, Prettier 정합
- 기존 멤버십 lib 테스트 5/5 통과
- 로컬 확인: `NEXT_PUBLIC_MEMBERSHIP_CHALLENGE_ID`를 보유 챌린지로 임시 지정 → 해당 카드만 "가이드 확인"으로 전환, 나머지 챌린지는 "대시보드 입장" 유지, 클릭 시 현재 탭 유지(새 탭 오픈) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)