### PR TITLE
feat(career-board): 커리어 관리 멤버십 카드도 '가이드 확인' 버튼 → 노션 새 탭

### DIFF
--- a/apps/web/src/domain/career-board/ui/CareerGrowthList.tsx
+++ b/apps/web/src/domain/career-board/ui/CareerGrowthList.tsx
@@ -54,6 +54,10 @@ const CareerGrowthItemCard = ({ config }: CareerGrowthItemCardProps) => {
     }
 
     if (actionButton.href) {
+      if (actionButton.external) {
+        window.open(actionButton.href, '_blank', 'noopener,noreferrer');
+        return;
+      }
       router.push(actionButton.href);
       return;
     }

--- a/apps/web/src/domain/career-board/utils/careerGrowthCard.ts
+++ b/apps/web/src/domain/career-board/utils/careerGrowthCard.ts
@@ -1,5 +1,9 @@
 import type { ApplicationDownloadType } from '@/api/application';
 import { MypageMagnetListItem } from '@/api/magnet/magnetSchema';
+import {
+  isMembershipChallengeProgram,
+  MEMBERSHIP_GUIDE_URL,
+} from '@/domain/membership/lib/membershipChallenge';
 import { ApplicationCategory } from '@/domain/mypage/application/constants';
 import dayjs from '@/lib/dayjs';
 import { PROGRAM_TYPE } from '@/utils/programConst';
@@ -26,6 +30,7 @@ export interface CareerGrowthCardConfig {
     label: string;
     disabled?: boolean;
     href?: string;
+    external?: boolean;
     onClick?: () => void;
     confirm?: {
       title: string;
@@ -58,11 +63,18 @@ export const toProgramCardConfig = (
     purchasePlanText:
       isChallenge && item.purchasePlan ? item.purchasePlan : undefined,
     actionButton: isChallenge
-      ? {
-          label: '대시보드 입장',
-          disabled: isDashboardDisabled,
-          href: `/challenge/${item.id}/${item.programId}`,
-        }
+      ? isMembershipChallengeProgram(item.programId)
+        ? {
+            label: '가이드 확인',
+            disabled: isDashboardDisabled,
+            href: MEMBERSHIP_GUIDE_URL,
+            external: true,
+          }
+        : {
+            label: '대시보드 입장',
+            disabled: isDashboardDisabled,
+            href: `/challenge/${item.id}/${item.programId}`,
+          }
       : undefined,
   };
 };


### PR DESCRIPTION
## 배경
직전 PR #2416 에서 **신청현황** 멤버십 카드를 '대시보드 입장' → '가이드 확인'(노션 안내 새 탭)으로 바꿨으나, **커리어 관리**(`/mypage/career/board` · 커리어 성장 섹션)는 신청현황과 **별도의 카드 config/renderer**를 써서 변경이 반영되지 않았습니다. 커리어 관리에도 동일 동작을 적용합니다.

## 변경
- `career-board/utils/careerGrowthCard.ts`
  - `isMembershipChallengeProgram`, `MEMBERSHIP_GUIDE_URL` import (기존 `membership` 도메인 헬퍼 재사용)
  - `actionButton` 타입에 `external?: boolean` 추가
  - 챌린지 분기에 멤버십 판별 → `가이드 확인` 라벨 + 노션 링크 + `external: true`
- `career-board/ui/CareerGrowthList.tsx`
  - `handleActionClick`에서 `external`이면 `window.open(..., '_blank', 'noopener,noreferrer')` 새 탭 처리

## 유지된 동작
- 참여예정(`programStatusType === 'PREV'`) 비활성 게이팅 그대로
- 일반 챌린지 카드는 '대시보드 입장' → `/challenge/{id}/{programId}` 이동 그대로

## 검증
- `tsc --noEmit` 0 errors · eslint clean · prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)