### PR TITLE
feat(membership): 플레이북 모바일 좌우 스와이프 캐러셀 + VOD 섹션 모바일 줄바꿈

### DIFF
--- a/apps/web/src/domain/membership/section/VodHookSection.tsx
+++ b/apps/web/src/domain/membership/section/VodHookSection.tsx
@@ -26,6 +26,8 @@ export default function VodHookSection() {
               {VOD_HOOK.titleTop}
               <br />
               {VOD_HOOK.titleBottomLead}
+              {/* 모바일에서만 줄바꿈: "…VOD를" 다음에서 끊어 "무료로 드려요"를 한 줄로 */}
+              <br className="vod-br-m" />
               <span className="vod-free">
                 <Sparkle className="vod-sparkle--sm" />
                 <span className="vod-free-text">

--- a/apps/web/src/domain/membership/styles/course-plan.css
+++ b/apps/web/src/domain/membership/styles/course-plan.css
@@ -186,6 +186,27 @@
   align-items: stretch;
 }
 
+/* 모바일 캐러셀 도트 인디케이터 — 데스크톱은 숨김(모바일 미디어쿼리에서 노출) */
+.membership-root .cp-dots {
+  display: none;
+}
+.membership-root .cp-dot {
+  width: 8px;
+  height: 8px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--g300);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    width 0.15s ease;
+}
+.membership-root .cp-dot[data-active='true'] {
+  width: 22px;
+  background: var(--lc-blue);
+}
+
 /* 카테고리 라벨 블록 — 카드(흰 배경·테두리)를 벗겨 "세로 축 행 헤더"로 둔다.
    왼쪽 컬러 액센트 바로 축임을 표시해 셀(데이터 카드)과 구분한다. */
 .membership-root .cpm-cat {
@@ -357,9 +378,13 @@
 .membership-root .wk-timeline {
   max-width: 1080px;
   margin: 0 auto;
+}
+/* 월 블록 스택(데스크톱). 모바일에서 가로 scroll-snap 트랙으로 전환된다. */
+.membership-root .wk-track {
   display: flex;
   flex-direction: column;
   gap: 30px;
+  margin-bottom: 30px;
 }
 .membership-root .wk-month {
   background: #fff;
@@ -584,11 +609,51 @@
   .membership-root .cpm-cells {
     grid-template-columns: 1fr;
   }
+  /* 매트릭스: 카테고리 카드를 좌우 스와이프 캐러셀로 (도트 + scroll-snap) */
+  .membership-root .cp-dots {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .membership-root .cpm-body {
+    flex-direction: row;
+    gap: 12px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    scroll-padding-inline: 16px;
+  }
+  .membership-root .cpm-body::-webkit-scrollbar {
+    display: none;
+  }
+  .membership-root .cpm-row {
+    flex: 0 0 88%;
+    scroll-snap-align: center;
+  }
   /* 월별: 2열 → 1열, 큰 숫자 축소 */
   .membership-root .wk-cards {
     grid-template-columns: 1fr;
   }
+  /* 월별: 월(月) 블록을 좌우 스와이프 캐러셀로 (도트는 .cp-dots 공용) */
+  .membership-root .wk-track {
+    flex-direction: row;
+    gap: 12px;
+    margin-bottom: 28px;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    scroll-padding-inline: 16px;
+  }
+  .membership-root .wk-track::-webkit-scrollbar {
+    display: none;
+  }
   .membership-root .wk-month {
+    flex: 0 0 88%;
+    scroll-snap-align: center;
     padding: 22px 20px 24px;
   }
   .membership-root .wk-mon {

--- a/apps/web/src/domain/membership/styles/vod-hook.css
+++ b/apps/web/src/domain/membership/styles/vod-hook.css
@@ -23,6 +23,10 @@
   font-weight: 800;
   letter-spacing: -0.04em;
 }
+/* 모바일 전용 줄바꿈용 <br> — 데스크톱은 숨김(PC 레이아웃 불변) */
+.membership-root .vod-br-m {
+  display: none;
+}
 /* "무료" 강조 — 브랜드 블루 그라디언트(오프브랜드 퍼플 제거) */
 .membership-root .vod-free {
   display: inline-flex;
@@ -203,6 +207,11 @@
   }
   .membership-root .vod-head h2 {
     font-size: 25px;
+    line-height: 1.32;
+  }
+  /* 모바일에서만 "…VOD를" 뒤 줄바꿈 노출 → "무료로 드려요" 한 줄 */
+  .membership-root .vod-br-m {
+    display: inline;
   }
   .membership-root .vod-card {
     flex-direction: column;
@@ -227,5 +236,9 @@
   .membership-root .vod-promo {
     font-size: 13.5px;
     padding: 13px 16px;
+    text-wrap: balance; /* 줄 길이 균형 — "제공해 드려요!" 홀로 남지 않게 */
+  }
+  .membership-root .vod-foot {
+    text-wrap: balance;
   }
 }

--- a/apps/web/src/domain/membership/ui/CarouselDots.tsx
+++ b/apps/web/src/domain/membership/ui/CarouselDots.tsx
@@ -1,0 +1,30 @@
+// 모바일 캐러셀 도트 인디케이터 (매트릭스·타임라인 공용). 데스크톱은 CSS 로 숨김.
+export default function CarouselDots({
+  count,
+  activeIndex,
+  onSelect,
+  label,
+  itemLabel,
+}: {
+  count: number;
+  activeIndex: number;
+  onSelect: (i: number) => void;
+  label: string;
+  itemLabel: (i: number) => string;
+}) {
+  return (
+    <div className="cp-dots" role="tablist" aria-label={label}>
+      {Array.from({ length: count }).map((_, i) => (
+        <button
+          key={i}
+          type="button"
+          className="cp-dot"
+          data-active={i === activeIndex ? 'true' : undefined}
+          aria-label={itemLabel(i)}
+          aria-current={i === activeIndex}
+          onClick={() => onSelect(i)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/domain/membership/ui/CoursePlanMatrix.tsx
+++ b/apps/web/src/domain/membership/ui/CoursePlanMatrix.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { useRef, type CSSProperties } from 'react';
 import {
   CATEGORIES,
   COURSE_TAG_LABEL,
@@ -10,6 +10,8 @@ import {
   STEPS,
   type Step,
 } from '../data/coursePlan';
+import CarouselDots from './CarouselDots';
+import { useCarouselDots } from './useCarouselDots';
 
 // 렛츠커리어가 직접 함께하는 챌린지 셀인지. (셀 색 강조용)
 // 무료 자료·템플릿·체크리스트(자료 제공) 셀은 강조 없이 흰 배경으로 둔다.
@@ -92,10 +94,22 @@ function CategoryRow({ category }: { category: Category }) {
 }
 
 export default function CoursePlanMatrix() {
+  // 모바일에서 .cpm-body 는 가로 scroll-snap 트랙이 된다(CSS). 도트는
+  // 공용 훅이 IntersectionObserver 로 활성 슬라이드를 추적한다.
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const { activeIndex, scrollToSlide } = useCarouselDots(bodyRef);
+
   return (
     <div className="cpm">
       <StepHeader />
-      <div className="cpm-body">
+      <CarouselDots
+        count={CATEGORIES.length}
+        activeIndex={activeIndex}
+        onSelect={scrollToSlide}
+        label="카테고리 넘기기"
+        itemLabel={(i) => CATEGORIES[i].label}
+      />
+      <div className="cpm-body" ref={bodyRef}>
         {CATEGORIES.map((category) => (
           <CategoryRow category={category} key={category.id} />
         ))}

--- a/apps/web/src/domain/membership/ui/CoursePlanTimeline.tsx
+++ b/apps/web/src/domain/membership/ui/CoursePlanTimeline.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { useRef, type CSSProperties } from 'react';
 import {
   FLOW_CHIPS,
   FLOW_LABEL,
@@ -7,6 +7,8 @@ import {
   WEEKS,
   type WeekItem,
 } from '../data/coursePlan';
+import CarouselDots from './CarouselDots';
+import { useCarouselDots } from './useCarouselDots';
 
 // 주차 번호 표기. 12·13 묶음이면 "12·13".
 function weekNo(item: WeekItem): string {
@@ -62,11 +64,24 @@ function MonthBlock({ group }: { group: MonthGroup }) {
 }
 
 export default function CoursePlanTimeline() {
+  // 모바일에서 .wk-track 은 가로 scroll-snap 트랙이 된다(CSS). 월(月) 블록이 슬라이드.
+  const trackRef = useRef<HTMLDivElement>(null);
+  const { activeIndex, scrollToSlide } = useCarouselDots(trackRef);
+
   return (
     <div className="wk-timeline">
-      {MONTH_GROUPS.map((group) => (
-        <MonthBlock group={group} key={group.month} />
-      ))}
+      <CarouselDots
+        count={MONTH_GROUPS.length}
+        activeIndex={activeIndex}
+        onSelect={scrollToSlide}
+        label="월 넘기기"
+        itemLabel={(i) => MONTH_GROUPS[i].month}
+      />
+      <div className="wk-track" ref={trackRef}>
+        {MONTH_GROUPS.map((group) => (
+          <MonthBlock group={group} key={group.month} />
+        ))}
+      </div>
 
       <div className="wk-flow">
         <p>

--- a/apps/web/src/domain/membership/ui/useCarouselDots.ts
+++ b/apps/web/src/domain/membership/ui/useCarouselDots.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState, type RefObject } from 'react';
+
+// 모바일 가로 scroll-snap 캐러셀의 활성 슬라이드 추적 + 도트 이동.
+// 트랙(ref)의 직계 자식이 슬라이드다. 데스크톱(가로 스크롤 없음)에서는
+// 도트가 CSS 로 숨겨지고 옵저버 결과도 쓰이지 않아 무해하다.
+export function useCarouselDots(trackRef: RefObject<HTMLElement | null>) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+    const slides = Array.from(track.children) as HTMLElement[];
+    if (!slides.length) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const idx = slides.indexOf(entry.target as HTMLElement);
+          if (idx !== -1) setActiveIndex(idx);
+        });
+      },
+      { root: track, threshold: 0.6 },
+    );
+    slides.forEach((slide) => observer.observe(slide));
+    return () => observer.disconnect();
+  }, [trackRef]);
+
+  const scrollToSlide = (i: number) => {
+    const slide = trackRef.current?.children[i] as HTMLElement | undefined;
+    if (!slide) return;
+    const reduce = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    slide.scrollIntoView({
+      inline: 'center',
+      block: 'nearest',
+      behavior: reduce ? 'auto' : 'smooth',
+    });
+  };
+
+  return { activeIndex, scrollToSlide };
+}


### PR DESCRIPTION
## 개요
`/membership` 하반기 멤버십 랜딩의 모바일 UX 개선 두 가지:
1. **플레이북(13주 플랜)** 전체·월별 뷰를 모바일에서 **좌우 스와이프 캐러셀**로
2. **VOD 훅 섹션**의 모바일 **줄바꿈/가독성** 개선

데스크톱(PC) 레이아웃은 두 변경 모두 **전혀 건드리지 않음**.

## 1. 플레이북 모바일 캐러셀
- 전체 플랜(매트릭스, 카테고리 6) · 월별 플랜(타임라인, 월 3)을 모바일(≤600px)에서 좌우로 넘기는 `scroll-snap` 캐러셀 + 상단 도트 인디케이터로 전환 (첨부 시안 형태)
- **공용화**: `useCarouselDots` 훅(IntersectionObserver 활성 추적 + 도트 이동) + `CarouselDots` 컴포넌트 신규 → 두 뷰가 공유. 도트 클래스 `.cp-dots/.cp-dot` 통일
- **단일 DOM + CSS 미디어쿼리 전환**(하이드레이션 안전), 기존 카드·배지 마크업 100% 재사용
- 데스크톱 그리드/월 스택 레이아웃 불변

## 2. VOD 섹션 모바일 줄바꿈 (PC 불변)
- 헤드라인: 모바일 전용 `<br>`(`vod-br-m`)로 "…VOD를" 뒤 줄바꿈 → "✨무료✨로 드려요"가 한 줄로(오펀 "드려요" 제거)
- 프로모 띠·하단 안내문: `text-wrap: balance`로 줄 길이 균형
- 모두 `@media (max-width:720px)` 한정

## 검증 (Playwright, 정확한 뷰포트)
- 모바일 390px: 전체/월별 캐러셀 도트·스냅·도트클릭 활성 추적 정상, VOD 헤드라인 3줄 클린·프로모 balance 확인
- 데스크톱 1280px: 매트릭스 그리드·월별 스택·VOD 2줄 헤드라인 **모두 불변** 확인
- typecheck · lint · prettier 통과

## 참고
- `CoursePlanSection`에 **기존** 하이드레이션 경고가 있으나 이 PR 변경과 무관(baseline/main 에도 존재)하며 동작 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)