### PR TITLE
fix(membership): 파트너 바로가기 링크 주소 수정 (산타토익·슈퍼인턴)

### DIFF
--- a/apps/web/src/domain/membership/ui/BenefitModal.tsx
+++ b/apps/web/src/domain/membership/ui/BenefitModal.tsx
@@ -390,7 +390,7 @@ function getModalContents(onClose: () => void): Record<string, ReactNode> {
             플랜 보고 멤버십 신청 →
           </button>
           <a
-            href="https://www.aitoeic.kr/"
+            href="https://kr.aitutorsanta.com/"
             target="_blank"
             rel="noopener noreferrer"
             className="modal-extbtn"

--- a/apps/web/src/domain/membership/ui/BenefitModal.tsx
+++ b/apps/web/src/domain/membership/ui/BenefitModal.tsx
@@ -550,7 +550,7 @@ function getModalContents(onClose: () => void): Record<string, ReactNode> {
             플랜 보고 멤버십 신청 →
           </button>
           <a
-            href="https://www.superintern.com/"
+            href="https://www.superpasshr.com/"
             target="_blank"
             rel="noopener noreferrer"
             className="modal-extbtn"


### PR DESCRIPTION
## 문제

멤버십 혜택 모달의 파트너 **"바로가기 →"** 버튼 링크가 잘못된 도메인을 가리켜 클릭 시 오류/엉뚱한 페이지로 연결됨.

## 변경

`apps/web/src/domain/membership/ui/BenefitModal.tsx`

```diff
# 산타토익 (line 393) — 최초 리포트된 버그
- href="https://www.aitoeic.kr/"
+ href="https://kr.aitutorsanta.com/"

# 슈퍼인턴 (line 553) — 코드 리뷰 중 발견한 동일 유형 버그
- href="https://www.superintern.com/"   # SSL 오류로 접속 불가, 무관한 도메인
+ href="https://www.superpasshr.com/"    # 실제 슈퍼인턴 서비스((주)이십사점오)
```

- 두 건 모두 JSX에 하드코딩된 도메인 오기입 문제.
- 링크 태그(`target="_blank" rel="noopener noreferrer"`)는 원래 올바르며 `href` 값만 교체.
- 슈퍼인턴 정정 주소는 웹 검색·접속으로 실제 슈퍼인턴 서비스 도메인임을 확인함.

## 검증

- [x] typecheck 통과
- [x] lint (변경 파일 이슈 없음)
- [x] prettier 포맷 통과
- [x] 로컬 dev 서버 `/membership` HTTP 200 정상 로드
- [x] `grep aitoeic|superintern.com` 잔여 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)