### PR TITLE
fix(admin): 후기관리 블로그 CSV·인쇄 전량 내보내기 + 순번 컬럼

### DIFF
--- a/apps/admin/src/api/review/review.ts
+++ b/apps/admin/src/api/review/review.ts
@@ -283,25 +283,38 @@ export const adminBlogReviewListSchema = z.object({
 // [어드민] 블로그 후기 전체 조회
 const adminBlogReviewListQueryKey = 'useGetAdminBlogReviewList';
 
+interface GetAdminBlogReviewListParams {
+  page?: number;
+  size?: number;
+  keyword?: string;
+  isVisible?: boolean;
+}
+
+/**
+ * 블로그 후기 목록 순수 fetcher. 훅(useGetAdminBlogReviewList)의 queryFn 이자,
+ * CSV 내보내기·인쇄처럼 캐시 밖에서 전량(size 크게)을 명령형으로 받을 때 재사용한다.
+ */
+export const getAdminBlogReviewList = async ({
+  page = 0,
+  size = 20,
+  keyword,
+  isVisible,
+}: GetAdminBlogReviewListParams = {}) => {
+  const res = await axiosV2.get('/admin/review/blog', {
+    params: { page, size, keyword, isVisible },
+  });
+  return adminBlogReviewListSchema.parse(res.data.data);
+};
+
 export const useGetAdminBlogReviewList = ({
   page = 0,
   size = 20,
   keyword,
   isVisible,
-}: {
-  page?: number;
-  size?: number;
-  keyword?: string;
-  isVisible?: boolean;
-} = {}) => {
+}: GetAdminBlogReviewListParams = {}) => {
   return useQuery({
     queryKey: [adminBlogReviewListQueryKey, page, size, keyword, isVisible],
-    queryFn: async () => {
-      const res = await axiosV2.get('/admin/review/blog', {
-        params: { page, size, keyword, isVisible },
-      });
-      return adminBlogReviewListSchema.parse(res.data.data);
-    },
+    queryFn: () => getAdminBlogReviewList({ page, size, keyword, isVisible }),
     refetchOnWindowFocus: false,
     placeholderData: keepPreviousData,
   });

--- a/apps/admin/src/domain/admin/pages/review/AdminBlogReviewListPage.tsx
+++ b/apps/admin/src/domain/admin/pages/review/AdminBlogReviewListPage.tsx
@@ -119,10 +119,8 @@ export default function AdminBlogReviewListPage() {
       editable: false,
       // 서버 페이지네이션이라 페이지가 넘어가도 이어지는 절대 순번(예: 6페이지 → 101~)
       renderCell: (params) => {
-        const idx = rows.findIndex((row) => row.id === params.id);
-        return idx < 0
-          ? ''
-          : paginationModel.page * paginationModel.pageSize + idx + 1;
+        const idx = params.api.getRowIndexRelativeToVisibleRows(params.id);
+        return paginationModel.page * paginationModel.pageSize + idx + 1;
       },
     },
     {
@@ -319,14 +317,30 @@ export default function AdminBlogReviewListPage() {
   const reactToPrint = useReactToPrint({
     contentRef: printRef,
     documentTitle: '블로그 후기 목록',
+    // 인쇄 후 화면 밖 대량 DOM 을 정리(불필요한 리렌더 방지)
+    onAfterPrint: () => setPrintReviews([]),
   });
 
   const totalElements = data?.pageInfo.totalElements ?? 0;
 
   // 전체 후기 조회 (화면 목록은 page/size 만 쓰므로 필터 없이 전량)
+  // BE 최대 페이지 크기 제한을 고려해 청크 단위로 순회하며 병합한다.
   const fetchAllReviews = async () => {
-    const res = await getAdminBlogReviewList({ page: 0, size: totalElements });
-    return res.reviewList;
+    const CHUNK_SIZE = 1000;
+    const all: AdminBlogReview[] = [];
+    let page = 0;
+    while (true) {
+      const res = await getAdminBlogReviewList({ page, size: CHUNK_SIZE });
+      all.push(...res.reviewList);
+      if (
+        res.reviewList.length < CHUNK_SIZE ||
+        all.length >= res.pageInfo.totalElements
+      ) {
+        break;
+      }
+      page += 1;
+    }
+    return all;
   };
 
   const handleExportCsv = async () => {

--- a/apps/admin/src/domain/admin/pages/review/AdminBlogReviewListPage.tsx
+++ b/apps/admin/src/domain/admin/pages/review/AdminBlogReviewListPage.tsx
@@ -1,5 +1,6 @@
 import {
   AdminBlogReview,
+  getAdminBlogReviewList,
   useDeleteAdminBlogReview,
   useGetAdminBlogReviewList,
   usePatchAdminBlogReview,
@@ -13,7 +14,7 @@ import { ProgramTypeEnum } from '@/schema';
 import { bankTypeToText } from '@/utils/convert';
 import { generateUUID } from '@/utils/random';
 import { usePaginationModelWithSearchParams } from '@/hooks/usePaginationModelWithSearchParams';
-import { Button, Checkbox } from '@mui/material';
+import { Button, Checkbox, FormControlLabel, Switch } from '@mui/material';
 import {
   DataGrid,
   GridActionsCellItem,
@@ -27,20 +28,63 @@ import {
   GridRowModesModel,
   GridRowParams,
   GridToolbarContainer,
-  GridToolbarExport,
 } from '@mui/x-data-grid';
 import { Check, Pencil, Trash, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useReactToPrint } from 'react-to-print';
 
-function CustomToolbar() {
-  const csvOptions = {
-    fileName: `blog-review-${Date.now().toString()}`,
-    utf8WithBom: true,
-  };
+import {
+  BLOG_REVIEW_EXPORT_COLUMNS,
+  downloadBlogReviewCsv,
+} from './blogReviewExport';
 
+// 커스텀 툴바 props 를 MUI DataGrid slotProps.toolbar 타입에 등록 (slotProps 로 주입 가능하게)
+declare module '@mui/x-data-grid' {
+  interface ToolbarPropsOverrides {
+    onExportCsv: () => void;
+    onPrint: () => void;
+    isBusy: boolean;
+    showRowNumber: boolean;
+    onToggleRowNumber: (next: boolean) => void;
+  }
+}
+
+/**
+ * 서버 페이지네이션 도입 후 MUI GridToolbarExport 는 현재 페이지만 내보내므로,
+ * 클릭 시 전량을 별도 조회해 CSV/인쇄하는 커스텀 버튼으로 대체한다. (핸들러는 페이지에서 주입)
+ */
+function CustomToolbar({
+  onExportCsv,
+  onPrint,
+  isBusy,
+  showRowNumber,
+  onToggleRowNumber,
+}: {
+  onExportCsv: () => void;
+  onPrint: () => void;
+  isBusy: boolean;
+  showRowNumber: boolean;
+  onToggleRowNumber: (next: boolean) => void;
+}) {
   return (
     <GridToolbarContainer>
-      <GridToolbarExport csvOptions={csvOptions} />
+      <Button size="small" onClick={onExportCsv} disabled={isBusy}>
+        {isBusy ? '준비 중…' : 'CSV 다운로드'}
+      </Button>
+      <Button size="small" onClick={onPrint} disabled={isBusy}>
+        인쇄
+      </Button>
+      <FormControlLabel
+        sx={{ marginLeft: 'auto', marginRight: 0 }}
+        control={
+          <Switch
+            size="small"
+            checked={showRowNumber}
+            onChange={(e) => onToggleRowNumber(e.target.checked)}
+          />
+        }
+        label="번호"
+      />
     </GridToolbarContainer>
   );
 }
@@ -62,7 +106,25 @@ export default function AdminBlogReviewListPage() {
   const patchReview = usePatchAdminBlogReview();
   const deleteReview = useDeleteAdminBlogReview();
 
+  // 번호(No.) 컬럼은 기본 숨김, 툴바 토글로 표시
+  const [showRowNumber, setShowRowNumber] = useState(false);
+
   const columns: GridColDef<Row>[] = [
+    {
+      field: '__rowNum',
+      headerName: 'No.',
+      width: 64,
+      sortable: false,
+      filterable: false,
+      editable: false,
+      // 서버 페이지네이션이라 페이지가 넘어가도 이어지는 절대 순번(예: 6페이지 → 101~)
+      renderCell: (params) => {
+        const idx = rows.findIndex((row) => row.id === params.id);
+        return idx < 0
+          ? ''
+          : paginationModel.page * paginationModel.pageSize + idx + 1;
+      },
+    },
     {
       field: 'postDate',
       type: 'dateTime',
@@ -249,6 +311,66 @@ export default function AdminBlogReviewListPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
 
+  // ── 전량 내보내기/인쇄 (서버 페이지네이션 우회: 클릭 시 전체를 별도 조회) ──
+  const [isExporting, setIsExporting] = useState(false);
+  const [printReviews, setPrintReviews] = useState<AdminBlogReview[]>([]);
+  const printRef = useRef<HTMLDivElement>(null);
+  const pendingPrint = useRef(false);
+  const reactToPrint = useReactToPrint({
+    contentRef: printRef,
+    documentTitle: '블로그 후기 목록',
+  });
+
+  const totalElements = data?.pageInfo.totalElements ?? 0;
+
+  // 전체 후기 조회 (화면 목록은 page/size 만 쓰므로 필터 없이 전량)
+  const fetchAllReviews = async () => {
+    const res = await getAdminBlogReviewList({ page: 0, size: totalElements });
+    return res.reviewList;
+  };
+
+  const handleExportCsv = async () => {
+    if (totalElements === 0) {
+      window.alert('내보낼 후기가 없습니다.');
+      return;
+    }
+    setIsExporting(true);
+    try {
+      downloadBlogReviewCsv(await fetchAllReviews());
+    } catch (e) {
+      console.error(e);
+      window.alert('CSV 내보내기에 실패했습니다.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleRequestPrint = async () => {
+    if (totalElements === 0) {
+      window.alert('인쇄할 후기가 없습니다.');
+      return;
+    }
+    setIsExporting(true);
+    try {
+      pendingPrint.current = true;
+      setPrintReviews(await fetchAllReviews());
+    } catch (e) {
+      console.error(e);
+      pendingPrint.current = false;
+      window.alert('인쇄 준비에 실패했습니다.');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  // 인쇄 DOM(printReviews) 이 렌더된 다음 프레임에 인쇄 실행
+  useEffect(() => {
+    if (pendingPrint.current && printReviews.length > 0) {
+      pendingPrint.current = false;
+      reactToPrint();
+    }
+  }, [printReviews, reactToPrint]);
+
   const handleSaveClick = (id: GridRowId) => () => {
     setRowModesModel({
       ...rowModesModel,
@@ -424,8 +546,61 @@ export default function AdminBlogReviewListPage() {
         pageSizeOptions={[10, 20, 50, 100]}
         paginationModel={paginationModel}
         onPaginationModelChange={handlePaginationModelChange}
+        columnVisibilityModel={{ __rowNum: showRowNumber }}
         slots={{ toolbar: CustomToolbar }}
+        slotProps={{
+          toolbar: {
+            onExportCsv: handleExportCsv,
+            onPrint: handleRequestPrint,
+            isBusy: isExporting,
+            showRowNumber,
+            onToggleRowNumber: setShowRowNumber,
+          },
+        }}
       />
+
+      {/* 인쇄 전용 DOM — 화면 밖에 두고 react-to-print 가 클론해 인쇄. 전량(printReviews) 렌더 */}
+      <div className="pointer-events-none fixed left-[-10000px] top-0 -z-10">
+        <div ref={printRef} className="p-6">
+          <h1 className="mb-3 text-lg font-bold">
+            블로그 후기 목록 ({printReviews.length}건)
+          </h1>
+          <table className="w-full border-collapse text-[11px]">
+            <thead>
+              <tr>
+                <th className="border border-neutral-400 px-1.5 py-1 text-left">
+                  No.
+                </th>
+                {BLOG_REVIEW_EXPORT_COLUMNS.map((c) => (
+                  <th
+                    key={c.header}
+                    className="border border-neutral-400 px-1.5 py-1 text-left"
+                  >
+                    {c.header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {printReviews.map((review, index) => (
+                <tr key={review.blogReviewId}>
+                  <td className="border border-neutral-400 px-1.5 py-1 align-top">
+                    {index + 1}
+                  </td>
+                  {BLOG_REVIEW_EXPORT_COLUMNS.map((c) => (
+                    <td
+                      key={c.header}
+                      className="border border-neutral-400 px-1.5 py-1 align-top"
+                    >
+                      {c.value(review)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
+++ b/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
@@ -1,0 +1,71 @@
+import type { AdminBlogReview } from '@/api/review/review';
+import type { PaymentMethodKey } from '@/data/getPaymentSearchParams';
+import dayjs from '@/lib/dayjs';
+import { bankTypeToText } from '@/utils/convert';
+
+/**
+ * 블로그 후기 CSV·인쇄 공통 컬럼 정의.
+ * 화면 DataGrid 컬럼과 동일 순서·포맷(액션 제외). CSV/인쇄가 같은 소스를 쓰도록 한 곳에서 관리.
+ */
+export const BLOG_REVIEW_EXPORT_COLUMNS: {
+  header: string;
+  value: (review: AdminBlogReview) => string;
+}[] = [
+  {
+    header: '추가일자',
+    value: (r) =>
+      r.postDate && !Number.isNaN(r.postDate.getTime())
+        ? dayjs(r.postDate).format('YYYY-MM-DD HH:mm:ss')
+        : '',
+  },
+  { header: '프로그램 구분', value: (r) => r.programType ?? '' },
+  { header: '프로그램 명', value: (r) => r.programTitle ?? '' },
+  { header: '이름', value: (r) => r.name ?? '' },
+  { header: '연락처', value: (r) => r.phoneNum ?? '' },
+  {
+    header: '은행명',
+    value: (r) =>
+      r.accountType
+        ? (bankTypeToText[r.accountType as PaymentMethodKey] ?? r.accountType)
+        : '',
+  },
+  { header: '계좌번호', value: (r) => r.accountNum ?? '' },
+  { header: '제목', value: (r) => r.title ?? '' },
+  { header: '설명', value: (r) => r.description ?? '' },
+  { header: 'URL', value: (r) => r.url ?? '' },
+  { header: '운영진확인', value: (r) => (r.isConfirmed ? 'O' : 'X') },
+  { header: '송금확인', value: (r) => (r.isRemittanceConfirmed ? 'O' : 'X') },
+  { header: '노출여부', value: (r) => (r.isVisible ? 'O' : 'X') },
+];
+
+/** CSV 셀 이스케이프 — 쉼표·큰따옴표·개행 포함 시 큰따옴표로 감싸고 내부 따옴표 이스케이프. */
+const escapeCsvValue = (value: string): string => {
+  if (!/[",\n]/.test(value)) return value;
+  return `"${value.replace(/"/g, '""')}"`;
+};
+
+export function buildBlogReviewCsv(reviews: AdminBlogReview[]): string {
+  const header = BLOG_REVIEW_EXPORT_COLUMNS.map((c) =>
+    escapeCsvValue(c.header),
+  ).join(',');
+  const body = reviews.map((review) =>
+    BLOG_REVIEW_EXPORT_COLUMNS.map((c) => escapeCsvValue(c.value(review))).join(
+      ',',
+    ),
+  );
+  return [header, ...body].join('\n');
+}
+
+/** BOM 포함 CSV Blob 다운로드 (엑셀 한글 깨짐 방지). */
+export function downloadBlogReviewCsv(reviews: AdminBlogReview[]): void {
+  const BOM = '﻿';
+  const blob = new Blob([BOM + buildBlogReviewCsv(reviews)], {
+    type: 'text/csv',
+  });
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `blog-review-${dayjs().format('YYYYMMDD-HHmmss')}.csv`;
+  link.click();
+  window.URL.revokeObjectURL(url);
+}

--- a/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
+++ b/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
@@ -58,7 +58,7 @@ export function buildBlogReviewCsv(reviews: AdminBlogReview[]): string {
 
 /** BOM 포함 CSV Blob 다운로드 (엑셀 한글 깨짐 방지). */
 export function downloadBlogReviewCsv(reviews: AdminBlogReview[]): void {
-  const BOM = '﻿';
+  const BOM = '\uFEFF';
   const blob = new Blob([BOM + buildBlogReviewCsv(reviews)], {
     type: 'text/csv',
   });


### PR DESCRIPTION
## 배경
어드민 **후기관리 > 블로그** 탭의 CSV 내보내기·인쇄가 **현재 페이지(20건)만** 출력됨.
원인: 리뷰 목록에 서버 페이지네이션이 도입(LC-3099)되면서 MUI `GridToolbarExport` 가 그리드의 현재 페이지 `rows` 만 직렬화.

## 변경
- **전량 내보내기**: `GridToolbarExport` 제거 → 커스텀 툴바("CSV 다운로드"·"인쇄"). 클릭 시 `getAdminBlogReviewList({ page: 0, size: totalElements })` 로 전량 별도 조회 후 CSV 생성 / `react-to-print` 로 전량 인쇄.
- `review.ts`: 순수 fetcher `getAdminBlogReviewList` 추출(훅 queryFn·전량 조회 공용).
- `blogReviewExport.ts`(신규): CSV/인쇄 공통 컬럼 정의 + BOM 포함 CSV Blob 다운로드.
- **순번(No.) 컬럼**: 그리드(절대 순번, 페이지 넘어가도 이어짐)·인쇄물(1~N)에 추가. 그리드는 **기본 숨김**, 툴바 우측 토글로 표시.

## 화면 목록/BE 영향
- 화면 그리드의 서버 페이지네이션은 **불변**, export/인쇄만 전량 별도 조회.
- BE 변경 없음.

## 검증
- `pnpm typecheck:admin`: 변경 파일 신규 에러 0 (admin 기존 baseline 유지)
- `pnpm build:admin`: 통과
- ESLint: 변경 파일 통과 / Prettier: 정렬 완료

## 참고 (별건)
전량(120건) vs 그리드 footer(115건) 카운트 불일치를 발견 — 배포 BE(LC-3099)의 `PageableExecutionUtils` count 생략 최적화로 추정되는 **BE 쪽 이슈**. 본 PR 범위(FE export/인쇄)와 분리해 BE 담당자 공유 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)