### PR TITLE
fix(admin): 후기 CSV 다운로드 Firefox 호환(<a> body 부착 후 클릭)

### DIFF
--- a/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
+++ b/apps/admin/src/domain/admin/pages/review/blogReviewExport.ts
@@ -66,6 +66,9 @@ export function downloadBlogReviewCsv(reviews: AdminBlogReview[]): void {
   const link = document.createElement('a');
   link.href = url;
   link.download = `blog-review-${dayjs().format('YYYYMMDD-HHmmss')}.csv`;
+  // Firefox 등에서 DOM 미부착 <a> 의 click() 이 무시될 수 있어 body 에 붙였다 제거
+  document.body.appendChild(link);
   link.click();
+  document.body.removeChild(link);
   window.URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
## 배경
PR #2427(후기관리 블로그 CSV·인쇄 전량) 머지 **직후** Gemini 리뷰가 남긴 마지막 지적을 반영하는 후속 PR입니다. 해당 지적은 #2427이 이미 머지된 뒤라 그 PR에 담기지 못했습니다.

## 변경
CSV 다운로드 시 동적 생성한 `<a>` 를 `document.body` 에 붙였다 클릭 후 제거.
- Firefox 등 일부 브라우저는 DOM 미부착 `<a>` 의 `click()` 을 무시해 다운로드가 시작되지 않을 수 있음.

`blogReviewExport.ts` 3줄 추가(표준 크로스브라우저 패턴).

## 검증
- `pnpm build:admin` 통과 / `pnpm typecheck:admin` 변경 파일 신규 에러 0 / ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)