### PR TITLE
LC-3147 feedback fields jitsi env

### DIFF
--- a/.claude/tasks/memos/verify-jitsi-server-auth.md
+++ b/.claude/tasks/memos/verify-jitsi-server-auth.md
@@ -1,0 +1,43 @@
+# Jitsi 서버 인증·인가 처리 확인 (석준님 요청)
+
+> 조사일 2026-07-10 · FE(this repo) + BE(`lets-career-server` `origin/dev`) 소스 기준
+
+## 요청
+
+석준님: "jitsi 서버 인증인가 처리 한번 확인 부탁드립니다."
+
+## 결론
+
+**앱(FE)·백엔드(BE) 어느 쪽에도 Jitsi 전용 인증·인가 로직이 없다.** 회의실은 사실상 오픈 룸이며,
+접근 보호는 *추측 불가한 랜덤 방 이름* 하나에만 의존한다. 실제 인증 게이팅 여부는
+`jitsi-meet.letscareer.co.kr` **셀프호스팅 서버 설정(Prosody/JWT 플러그인) 레벨에서 별도 확인**이 필요하다.
+
+## 근거
+
+### BE (`origin/dev`)
+
+- `jitsi`·JWT-for-jitsi·JaaS·moderator·room-auth 토큰 생성 코드 **0건**(대소문자 무시 grep 전무).
+  BE의 유일한 JWT(`global/security/jwt/TokenProvider`, `JwtAuthenticationFilter`, `WebSecurityConfig`)는
+  앱 자체 REST API용 Spring Security 인증으로 **Jitsi와 무관**.
+- 방 이름은 서버 랜덤 NanoID: `meetingRoom = nanoIdGenerator.generate()`
+  (`FeedbackServiceImpl.createFeedback`). 미션/피드백 id 파생 아님.
+- 최종 URL은 `meetingUrl = base(FE 전달) + meetingRoom` 단순 합성
+  (`FeedbackServiceImpl.updateFeedbackMeetingUrl`). base(호스트)는 FE env에서 옴.
+
+### FE
+
+- `packages/ui/src/JitsiEmbed/*`는 방 URL을 그대로 iframe에 로드할 뿐 토큰/`jwt` 파라미터를 붙이지 않음.
+- 방 이름 추측 난이도는 `NEXT_PUBLIC_JITSI_ROOM_SALT` / `VITE_JITSI_ROOM_SALT`(web·mentor 동일 값)로만 보강.
+
+## 보안 관점 정리
+
+- 현재 상태 = **인가 없음 + 추측 난이도**. 링크(랜덤 room)를 아는 사람은 인증 없이 입장 가능.
+- 민감 세션이면 서버단 JWT(Prosody `token` 모듈)로 도메인·방·moderator 게이팅을 켜는 것을 권장.
+  이 경우 BE가 방별 JWT를 발급해 `meetingUrl`에 `?jwt=` 로 실어 보내는 계약이 추가로 필요
+  (현재 계약엔 없음 → BE 협의 사항).
+
+## 관련
+
+- 신규 도메인 `jitsi-meet.letscareer.co.kr`을 web·mentor `.env.example` + mentor `.env.prod`의
+  `*_JITSI_BASE_URL` 값으로 반영함(같은 커밋).
+- `GET /feedback/{id}` 3필드(`programTitle/mentorName/menteeName`, BE LC-3147) FE 스키마 반영함.

--- a/.claude/tasks/memos/verify-jitsi-server-auth.md
+++ b/.claude/tasks/memos/verify-jitsi-server-auth.md
@@ -38,6 +38,8 @@
 
 ## 관련
 
-- 신규 도메인 `jitsi-meet.letscareer.co.kr`을 web·mentor `.env.example` + mentor `.env.prod`의
-  `*_JITSI_BASE_URL` 값으로 반영함(같은 커밋).
+- 신규 도메인 `jitsi-meet.letscareer.co.kr`을 web·mentor `.env.example`의 `*_JITSI_BASE_URL`
+  값으로 반영함(이 PR 포함). `apps/mentor/.env.prod`는 gitignore 대상이라 로컬만 반영됨.
+  web 프로덕션은 Vercel env `NEXT_PUBLIC_JITSI_BASE_URL`을 별도 갱신해야 하며,
+  `ROOM_SALT`는 web·mentor 동일 값 유지 필요.
 - `GET /feedback/{id}` 3필드(`programTitle/mentorName/menteeName`, BE LC-3147) FE 스키마 반영함.

--- a/apps/mentor/.env.example
+++ b/apps/mentor/.env.example
@@ -75,8 +75,8 @@ VITE_ZEP_SPACE_NAME=
 # 셀프호스팅 단일 서버를 사용한다.
 
 # Jitsi 셀프호스팅 서버 베이스 URL. 끝에 슬래시 포함 권장.
-# 예) https://jitsi-ayjsueey4v9euvyy9gsgmmtz.supabin.com/
-VITE_JITSI_BASE_URL=
+# 예) https://jitsi-meet.letscareer.co.kr/
+VITE_JITSI_BASE_URL=https://jitsi-meet.letscareer.co.kr/
 
 # Jitsi 폴백(셀프호스팅) 서버 베이스 URL.
 # 예) https://jitsi-letscareer.supabin.com/

--- a/apps/mentor/src/api/feedback/feedbackSchema.ts
+++ b/apps/mentor/src/api/feedback/feedbackSchema.ts
@@ -66,6 +66,13 @@ export const feedbackSchema = z.object({
   endDate: z.string(),
   meetingUrl: z.string().nullable(),
   status: feedbackStatusSchema,
+  /**
+   * BE `FeedbackVo` 추가 필드 (LC-3147: programTitle·mentorName·menteeName).
+   * 멘토 대상 환경 배포 시점차로 비어 올 수 있어 nullish forward-compatible.
+   */
+  programTitle: z.string().nullish(),
+  mentorName: z.string().nullish(),
+  menteeName: z.string().nullish(),
 });
 export type Feedback = z.infer<typeof feedbackSchema>;
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -115,8 +115,8 @@ NEXT_PUBLIC_ZEP_SPACE_NAME=
 # ⚠️ ROOM_SALT 는 멘토(apps/mentor/.env)와 반드시 동일해야 같은 방으로 수렴.
 
 # Jitsi 셀프호스팅 서버 베이스 URL. 끝에 슬래시 포함 권장.
-# 예) https://jitsi-ayjsueey4v9euvyy9gsgmmtz.supabin.com/
-NEXT_PUBLIC_JITSI_BASE_URL=
+# 예) https://jitsi-meet.letscareer.co.kr/
+NEXT_PUBLIC_JITSI_BASE_URL=https://jitsi-meet.letscareer.co.kr/
 
 # Jitsi 폴백(셀프호스팅) 서버 베이스 URL.
 # 예) https://jitsi-letscareer.supabin.com/


### PR DESCRIPTION
## 배경

BE(석준님)가 `origin/dev`에서 `GET /feedback/{id}` 응답 VO(`FeedbackVo`)에 3필드를 추가(커밋 `014c1956 LC-3147-fix ... programTitle, mentorName, menteeName 추가`). FE만 여기에 맞추면 되고, 함께 신규 jitsi 셀프호스팅 도메인 `jitsi-meet.letscareer.co.kr`을 env에 반영한다.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `apps/mentor/src/api/feedback/feedbackSchema.ts` | `feedbackSchema`에 `programTitle`·`mentorName`·`menteeName` 추가 (nullish forward-compatible) |
| `apps/web/.env.example` | `NEXT_PUBLIC_JITSI_BASE_URL` = `https://jitsi-meet.letscareer.co.kr/` |
| `apps/mentor/.env.example` | `VITE_JITSI_BASE_URL` = `https://jitsi-meet.letscareer.co.kr/` |
| `.claude/tasks/memos/verify-jitsi-server-auth.md` | jitsi 서버 인증·인가 확인 보고 |

`.nullish()`로 둔 이유: 이 파일의 기존 관례(`th` nullish, `meetingUrl` "BE 미배포") 및 web `feedbackDetailSchema`의 동일 3필드 선례와 일치. 멘토 대상 환경 배포 시점차로 필드가 비어 와도 parse 실패하지 않는다.

## 확인만 (코드 변경 불필요)

- **jitsi mission→feedback id**: FE·BE 알림톡/입장 링크 모두 이미 `feedbackId` 사용 중. FE의 "mission id"는 캘린더 바 key용 합성값(`-feedbackId`)뿐, jitsi와 무관.
- **web `feedbackDetailSchema`**: 3필드가 이미 nullish로 존재.

## jitsi 인증·인가 확인 (석준님 요청)

BE·앱 어디에도 jitsi 전용 인증·인가 로직 없음. 방은 랜덤 room 이름(`NanoIdGenerator`)에만 의존하는 사실상 오픈 룸이며, BE는 `base + meetingRoom` 합성만 함. 실제 게이팅 여부는 `jitsi-meet.letscareer.co.kr` **서버 설정(Prosody/JWT) 레벨에서 별도 확인 필요**. 상세는 메모 참고.

> ⚠️ 배포 시: web 프로덕션은 Vercel env `NEXT_PUBLIC_JITSI_BASE_URL`을 별도 갱신해야 하며, `ROOM_SALT`는 web·mentor 동일 값 유지 필요.

## 검증

- ✅ `pnpm typecheck` (mentor) 통과
- ✅ `feedbackSchema` 관련 테스트 통과 (53 passed)
- ✅ 변경 스키마 lint clean
- ℹ️ `mentorMswHandlers.test.ts` 1건 실패는 본 변경과 무관한 사전 존재 실패(다른 스키마 `attendanceUrl` MSW 목 불일치, stash 재실행으로 확증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [LC-3147]

[LC-3147]:https://letscareer-team.atlassian.net/browse/LC-3147


[LC-3147]: https://letscareer-team.atlassian.net/browse/LC-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ