### PR TITLE
fix: 미션 템플릿 미선택 시 빈 미션명 저장 방지 (피드백 관리 미션명 공백 버그)

### DIFF
--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -114,14 +114,22 @@ export const useMissionOperations = (
     }) => {
       // 미션 title 은 선택한 템플릿에서만 파생한다. 템플릿이 확정되지 않으면
       // title 이 빈 문자열로 저장돼 목록·피드백에서 미션명이 공백이 되므로 저장을 막는다.
-      const resolvedTitle = row.missionTemplatesOptions.find(
-        (t) => t.id === row.missionTemplateId,
-      )?.title;
+      const resolvedTitle = row.missionTemplateId
+        ? row.missionTemplatesOptions?.find(
+            (t) => t.id === row.missionTemplateId,
+          )?.title
+        : undefined;
 
       switch (action) {
         case 'create':
-          if (!row.missionTemplateId || !resolvedTitle) {
+          if (!row.missionTemplateId) {
             setSnackbar('미션 템플릿을 선택해주세요.');
+            return;
+          }
+          if (!resolvedTitle) {
+            setSnackbar(
+              '존재하지 않거나 삭제된 미션 템플릿입니다. 다른 템플릿을 선택해주세요.',
+            );
             return;
           }
           await createMissionMutation.mutateAsync({
@@ -156,8 +164,14 @@ export const useMissionOperations = (
         case 'edit':
           // 템플릿 목록 미로딩·템플릿 삭제 등으로 title 이 해석되지 않으면
           // 기존 title 을 빈 문자열로 덮어쓰지 않도록 저장을 막는다.
-          if (!row.missionTemplateId || !resolvedTitle) {
+          if (!row.missionTemplateId) {
             setSnackbar('미션 템플릿을 선택해주세요.');
+            return;
+          }
+          if (!resolvedTitle) {
+            setSnackbar(
+              '존재하지 않거나 삭제된 미션 템플릿입니다. 다른 템플릿을 선택해주세요.',
+            );
             return;
           }
           await updateMission.mutateAsync({
@@ -243,6 +257,8 @@ export const useMissionOperations = (
   const rows = useMemo((): Row[] => {
     const result: Row[] = (missions ?? []).map((m) => ({
       ...m,
+      challengeOptionId: m.challengeOptionId ?? null,
+      challengeOptionCode: m.challengeOptionCode ?? null,
       mode: 'normal',
       additionalContentsOptions: additionalContents,
       essentialContentsOptions: essentialContents,
@@ -253,6 +269,8 @@ export const useMissionOperations = (
     if (editingMission) {
       result.push({
         ...editingMission,
+        challengeOptionId: editingMission.challengeOptionId ?? null,
+        challengeOptionCode: editingMission.challengeOptionCode ?? null,
         mode: 'create',
         additionalContentsOptions: additionalContents,
         essentialContentsOptions: essentialContents,

--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -112,8 +112,18 @@ export const useMissionOperations = (
       action: 'create' | 'edit' | 'delete' | 'cancel';
       row: Row;
     }) => {
+      // 미션 title 은 선택한 템플릿에서만 파생한다. 템플릿이 확정되지 않으면
+      // title 이 빈 문자열로 저장돼 목록·피드백에서 미션명이 공백이 되므로 저장을 막는다.
+      const resolvedTitle = row.missionTemplatesOptions.find(
+        (t) => t.id === row.missionTemplateId,
+      )?.title;
+
       switch (action) {
         case 'create':
+          if (!row.missionTemplateId || !resolvedTitle) {
+            setSnackbar('미션 템플릿을 선택해주세요.');
+            return;
+          }
           await createMissionMutation.mutateAsync({
             additionalContentsIdList:
               row.additionalContentsList
@@ -132,10 +142,7 @@ export const useMissionOperations = (
               .tz()
               .format('YYYY-MM-DDTHH:mm:ss'),
             th: row.th,
-            title:
-              row.missionTemplatesOptions.find(
-                (t) => t.id === row.missionTemplateId,
-              )?.title ?? '',
+            title: resolvedTitle,
             missionType: row.missionType,
           });
           if (apiRef?.current?.getRowMode(row.id) === 'edit') {
@@ -147,7 +154,10 @@ export const useMissionOperations = (
           return;
 
         case 'edit':
-          if (!row.missionTemplateId) {
+          // 템플릿 목록 미로딩·템플릿 삭제 등으로 title 이 해석되지 않으면
+          // 기존 title 을 빈 문자열로 덮어쓰지 않도록 저장을 막는다.
+          if (!row.missionTemplateId || !resolvedTitle) {
+            setSnackbar('미션 템플릿을 선택해주세요.');
             return;
           }
           await updateMission.mutateAsync({
@@ -170,10 +180,7 @@ export const useMissionOperations = (
               .tz()
               .format('YYYY-MM-DDTHH:mm:ss'),
             th: row.th,
-            title:
-              row.missionTemplatesOptions.find(
-                (t) => t.id === row.missionTemplateId,
-              )?.title ?? '',
+            title: resolvedTitle,
           });
           if (apiRef?.current?.getRowMode(row.id) === 'edit') {
             apiRef.current?.stopRowEditMode({ id: row.id });


### PR DESCRIPTION
## 문제

어드민 **챌린지 운영 > 피드백 > 피드백 관리** 목록에서 대부분의 미션 행 **"미션 명" 컬럼이 공백**으로 표시됨 (회차·날짜·피드백 타입·옵션·제출수는 정상).

## 원인

목록/서버는 `mission.title`을 그대로 전달할 뿐이고, 실제로는 **미션 생성 시 title이 빈 문자열로 저장되는 클라이언트 결함**이었습니다.

- 미션 title은 선택한 미션 템플릿에서 파생: `find(...)?.title ?? ''`
- **create 경로에 `missionTemplateId` 필수 가드가 없음** (edit 경로엔 존재). 템플릿 미선택으로 생성하면 `title: ''`로 `POST /mission/{id}` 전송
- 이후 피드백 옵션만 연결(`useUpdateMissionOption`, title 미변경)되어 "미션명 없는 피드백 미션"이 완성됨

## 수정

`apps/admin/src/hooks/useMissionOperation.ts` (단일 파일)

- `resolvedTitle`을 switch 진입 전 한 번 계산
- **create**: `missionTemplateId`/`resolvedTitle` 없으면 `"미션 템플릿을 선택해주세요."` 스낵바 후 저장 차단
- **edit**: 템플릿 목록 미로딩·삭제로 title 미해석 시 기존 title을 `''`로 덮어쓰지 않도록 동일 차단
- 빈 문자열 폴백(`?? ''`) 제거 → "템플릿에서 title이 확정될 때만 저장"으로 통일

## 검증

- 변경 파일 기준 typecheck 신규 에러 0건 (기존 244/254행 에러는 이번 변경과 무관한 사전 존재)
- ESLint 통과, Prettier 통과

## 남은 사항 (코드 밖)

- 이미 title이 빈 기존 미션은 이 수정으로 자동 복구되지 않음 → "미션등록"에서 템플릿 선택 후 재저장 필요. 다수면 BE 백필 요청 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)