### PR TITLE
fix: Jitsi 회의실 로드 실패 시 다른 서버로 자동 failover

### DIFF
--- a/apps/mentor/src/pages/schedule/modal/JitsiEmbedModal.tsx
+++ b/apps/mentor/src/pages/schedule/modal/JitsiEmbedModal.tsx
@@ -47,6 +47,12 @@ interface JitsiEmbedModalProps {
   onSaveAttendance?: (status: FeedbackAttendanceStatus) => void;
   /** 출석 저장 진행 중 여부 — 버튼 로딩. */
   isSavingAttendance?: boolean;
+  /** 우선순위 순 jitsi base 후보 — 현재 서버 실패 시 다음 후보로 failover. */
+  baseCandidates?: ReadonlyArray<string | undefined>;
+  /** 다음 base 를 BE 에 재등록하는 콜백 (`PATCH /feedback/{id}/meeting-url`). */
+  registerBaseUrl?: (base: string) => Promise<void>;
+  /** 모든 후보 소진(입장 가능한 서버 없음) 시 호출. */
+  onExhausted?: () => void;
 }
 
 interface MenteeAttendanceBarProps {
@@ -224,6 +230,9 @@ const JitsiEmbedModal = ({
   isMentor,
   menteeStatus,
   onSaveAttendance,
+  baseCandidates,
+  registerBaseUrl,
+  onExhausted,
 }: JitsiEmbedModalProps) => {
   const [openPanel, setOpenPanel] = useState<MaterialPanel | null>(null);
 
@@ -290,6 +299,9 @@ const JitsiEmbedModal = ({
               roomUrl={meetingUrl}
               spaceName={spaceName}
               onClose={handleClose}
+              baseCandidates={baseCandidates}
+              registerBaseUrl={registerBaseUrl}
+              onExhausted={onExhausted}
               topLeftSlot={
                 startDate && endDate ? (
                   <LiveSessionTimer startDate={startDate} endDate={endDate} />

--- a/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
+++ b/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
@@ -647,6 +647,20 @@ const LiveFeedbackReservationModal = ({
           onClose={() => setIsJitsiOpen(false)}
           meetingUrl={meetingUrl}
           spaceName={selectedBar?.challengeTitle}
+          // 입장 후 현재 서버가 죽어있으면(external_api.js 로드 실패) 다음 후보로 자동
+          // 재등록(failover). BE 는 base + meetingRoom 을 덮어써 합성한다.
+          baseCandidates={[
+            import.meta.env.VITE_JITSI_BASE_URL,
+            import.meta.env.VITE_JITSI_FALLBACK_URL,
+          ]}
+          registerBaseUrl={async (base) => {
+            await updateMeetingUrl({ feedbackId, meetingUrl: base });
+          }}
+          onExhausted={() =>
+            window.alert(
+              '회의실 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+            )
+          }
           // 좌측 자료 패널 — 사전 Q&A(없으면 숨김) · 제출물.
           // placeholder('-')/빈 문자열은 패널 빈 상태 판정을 위해 undefined 로 전달.
           preQuestion={feedbackDetail?.preQuestion ?? undefined}

--- a/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
+++ b/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
@@ -213,6 +213,12 @@ const LiveFeedbackReservationModal = ({
       // invalidate 로 feedbackDetail.meetingUrl 이 곧 채워지지만, 즉시 입장 경험을 위해
       // 모달을 바로 연다(JitsiEmbedModal 이 갱신된 URL 수신).
       setIsJitsiOpen(true);
+    } catch (error) {
+      // 헬스체크/등록 중 네트워크·서버 오류 — 미처리 시 unhandled rejection.
+      console.error('라이브 입장 준비 중 오류:', error);
+      window.alert(
+        '회의실 연결을 준비하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      );
     } finally {
       setIsPreparingRoom(false);
     }

--- a/apps/web/src/common/modal/JitsiEmbedModal.tsx
+++ b/apps/web/src/common/modal/JitsiEmbedModal.tsx
@@ -18,6 +18,12 @@ interface JitsiEmbedModalProps {
   meetingUrl: string | null;
   /** 모달 헤더 표시용 라벨 (선택). URL 에는 영향 없음. */
   spaceName?: string;
+  /** 우선순위 순 jitsi base 후보 — 현재 서버 실패 시 다음 후보로 failover. */
+  baseCandidates?: ReadonlyArray<string | undefined>;
+  /** 다음 base 를 BE 에 재등록하는 콜백 (`PATCH /feedback/{id}/meeting-url`). */
+  registerBaseUrl?: (base: string) => Promise<void>;
+  /** 모든 후보 소진(입장 가능한 서버 없음) 시 호출. */
+  onExhausted?: () => void;
 }
 
 const JitsiEmbedModal = ({
@@ -25,6 +31,9 @@ const JitsiEmbedModal = ({
   onClose,
   meetingUrl,
   spaceName,
+  baseCandidates,
+  registerBaseUrl,
+  onExhausted,
 }: JitsiEmbedModalProps) => {
   return (
     <BaseModal
@@ -37,6 +46,9 @@ const JitsiEmbedModal = ({
           roomUrl={meetingUrl}
           spaceName={spaceName}
           onClose={onClose}
+          baseCandidates={baseCandidates}
+          registerBaseUrl={registerBaseUrl}
+          onExhausted={onExhausted}
         />
       ) : (
         <div className="flex h-full items-center justify-center p-8 text-center text-sm text-neutral-500">

--- a/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
+++ b/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
@@ -69,6 +69,12 @@ const ReservationInfoSection = ({
         return;
       }
       setIsJitsiOpen(true);
+    } catch (error) {
+      // 헬스체크/등록 중 네트워크·서버 오류 — 미처리 시 unhandled rejection.
+      console.error('라이브 입장 준비 중 오류:', error);
+      window.alert(
+        '회의실 연결을 준비하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      );
     } finally {
       setIsPreparingRoom(false);
     }

--- a/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
+++ b/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
@@ -157,6 +157,20 @@ const ReservationInfoSection = ({
           onClose={() => setIsJitsiOpen(false)}
           meetingUrl={meetingUrl ?? null}
           spaceName={mentor.nickname}
+          // 입장 후 현재 서버가 죽어있으면(external_api.js 로드 실패) 다음 후보로 자동
+          // 재등록(failover). BE 는 base + meetingRoom 을 덮어써 합성한다.
+          baseCandidates={[
+            process.env.NEXT_PUBLIC_JITSI_BASE_URL,
+            process.env.NEXT_PUBLIC_JITSI_FALLBACK_URL,
+          ]}
+          registerBaseUrl={async (base) => {
+            await patchMeetingUrl.mutateAsync({ meetingUrl: base });
+          }}
+          onExhausted={() =>
+            window.alert(
+              '회의실 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+            )
+          }
         />
       )}
     </div>

--- a/apps/web/src/domain/live-feedback/LiveFeedbackEntryPage.tsx
+++ b/apps/web/src/domain/live-feedback/LiveFeedbackEntryPage.tsx
@@ -36,7 +36,14 @@ export default function LiveFeedbackEntryPage({ feedbackId, role }: Props) {
   );
   const feedbackInfo = data?.feedbackInfo ?? null;
 
-  const { isOpen, isPreparing, enter, closeJitsi } = useLiveEntry({
+  const {
+    isOpen,
+    isPreparing,
+    enter,
+    closeJitsi,
+    baseCandidates,
+    registerBaseUrl,
+  } = useLiveEntry({
     feedbackId,
     feedbackInfo,
     role,
@@ -103,6 +110,15 @@ export default function LiveFeedbackEntryPage({ feedbackId, role }: Props) {
         menteeStatus={feedbackInfo?.menteeStatus ?? undefined}
         onSaveAttendance={(menteeStatus) =>
           patchStatus.mutate({ menteeStatus })
+        }
+        // 입장 후 현재 서버가 죽어있으면(external_api.js 로드 실패) 다음 후보로 자동
+        // 재등록(failover). BE 는 base + meetingRoom 을 덮어써 합성한다.
+        baseCandidates={baseCandidates}
+        registerBaseUrl={registerBaseUrl}
+        onExhausted={() =>
+          window.alert(
+            '회의실 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.',
+          )
         }
       />
     </main>

--- a/apps/web/src/domain/live-feedback/hooks/useLiveEntry.ts
+++ b/apps/web/src/domain/live-feedback/hooks/useLiveEntry.ts
@@ -95,6 +95,12 @@ export function useLiveEntry({
       }
 
       setIsOpen(true);
+    } catch (error) {
+      // 헬스체크/등록 중 네트워크·서버 오류 — 미처리 시 unhandled rejection.
+      console.error('라이브 입장 준비 중 오류:', error);
+      window.alert(
+        '회의실 연결을 준비하는 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.',
+      );
     } finally {
       setIsPreparing(false);
     }

--- a/apps/web/src/domain/live-feedback/hooks/useLiveEntry.ts
+++ b/apps/web/src/domain/live-feedback/hooks/useLiveEntry.ts
@@ -27,7 +27,17 @@ interface LiveEntry {
   enter: () => Promise<void>;
   /** 인라인 Jitsi 닫기. */
   closeJitsi: () => void;
+  /** 우선순위 순 jitsi base 후보 — JitsiEmbed failover 주입용. */
+  baseCandidates: ReadonlyArray<string | undefined>;
+  /** 다음 base 재등록(overwrite PATCH) — JitsiEmbed failover 주입용. */
+  registerBaseUrl: (base: string) => Promise<void>;
 }
+
+/** 우선순위 순 jitsi base 후보 (env). 모듈 상수로 두어 안정적 참조. */
+const JITSI_BASE_CANDIDATES: ReadonlyArray<string | undefined> = [
+  process.env.NEXT_PUBLIC_JITSI_BASE_URL,
+  process.env.NEXT_PUBLIC_JITSI_FALLBACK_URL,
+];
 
 /**
  * 라이브 입장 핵심 로직 (멘토·멘티 공통).
@@ -52,20 +62,20 @@ export function useLiveEntry({
   const patchMeetingUrl = usePatchFeedbackMeetingUrl(feedbackId);
   const patchMentorStatus = usePatchMentorFeedbackStatus(feedbackId);
 
+  // BE 가 base + meetingRoom 을 합성하므로 FE 는 base URL 만 보낸다.
+  // 최초 등록(ensureLiveMeetingUrl)과 실행 중 failover(JitsiEmbed)가 함께 쓴다.
+  const registerBaseUrl = async (base: string) => {
+    await patchMeetingUrl.mutateAsync({ meetingUrl: base });
+  };
+
   const enter = async () => {
     if (isPreparing) return;
     setIsPreparing(true);
     try {
       const result = await ensureLiveMeetingUrl({
         meetingUrl: feedbackInfo?.meetingUrl,
-        baseCandidates: [
-          process.env.NEXT_PUBLIC_JITSI_BASE_URL,
-          process.env.NEXT_PUBLIC_JITSI_FALLBACK_URL,
-        ],
-        // BE 가 base + meetingRoom 을 합성하므로 FE 는 base URL 만 보낸다.
-        registerBaseUrl: async (base) => {
-          await patchMeetingUrl.mutateAsync({ meetingUrl: base });
-        },
+        baseCandidates: JITSI_BASE_CANDIDATES,
+        registerBaseUrl,
       });
 
       if (!result.ok) {
@@ -92,5 +102,12 @@ export function useLiveEntry({
 
   const closeJitsi = () => setIsOpen(false);
 
-  return { isOpen, isPreparing, enter, closeJitsi };
+  return {
+    isOpen,
+    isPreparing,
+    enter,
+    closeJitsi,
+    baseCandidates: JITSI_BASE_CANDIDATES,
+    registerBaseUrl,
+  };
 }

--- a/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
+++ b/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
@@ -30,6 +30,12 @@ interface LiveFeedbackModalProps {
   menteeStatus?: AttendanceStatus;
   /** 출석 저장(모달 닫힘/종료 시 일괄). */
   onSaveAttendance?: (status: AttendanceStatus) => void;
+  /** 우선순위 순 jitsi base 후보 — 현재 서버 실패 시 다음 후보로 failover. */
+  baseCandidates?: ReadonlyArray<string | undefined>;
+  /** 다음 base 를 BE 에 재등록하는 콜백 (`PATCH /feedback/{id}/meeting-url`). */
+  registerBaseUrl?: (base: string) => Promise<void>;
+  /** 모든 후보 소진(입장 가능한 서버 없음) 시 호출. */
+  onExhausted?: () => void;
 }
 
 type MaterialPanel = 'qna' | 'submission';
@@ -210,6 +216,9 @@ const LiveFeedbackModal = ({
   endDate,
   menteeStatus,
   onSaveAttendance,
+  baseCandidates,
+  registerBaseUrl,
+  onExhausted,
 }: LiveFeedbackModalProps) => {
   const [openPanel, setOpenPanel] = useState<MaterialPanel | null>(null);
 
@@ -278,6 +287,9 @@ const LiveFeedbackModal = ({
               roomUrl={meetingUrl}
               spaceName={spaceName}
               onClose={handleClose}
+              baseCandidates={baseCandidates}
+              registerBaseUrl={registerBaseUrl}
+              onExhausted={onExhausted}
               topLeftSlot={
                 startDate && endDate ? (
                   <LiveSessionTimer startDate={startDate} endDate={endDate} />

--- a/packages/ui/src/JitsiEmbed/index.test.tsx
+++ b/packages/ui/src/JitsiEmbed/index.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, type Mock } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 /**
  * @jitsi/react-sdk를 mock으로 대체.
@@ -16,9 +16,23 @@ vi.mock('@jitsi/react-sdk', () => ({
   },
 }));
 
-// mock 이후에 import — vi.mock 호이스팅 효과를 위해 동적 import 형태 사용
+/**
+ * external_api.js 프로브를 mock 한다. jsdom 은 <script> 를 실제로 로드하지 않아
+ * 실제 프로브는 타임아웃까지 pending 되므로, 성공/실패를 테스트에서 제어한다.
+ * pickNextBase/safeHost 등 순수 로직은 실제 구현을 그대로 쓴다(부분 mock).
+ */
+vi.mock('./jitsiHealthCheck', async (importActual) => {
+  const actual = await importActual<typeof import('./jitsiHealthCheck')>();
+  return { ...actual, probeJitsiExternalApi: vi.fn() };
+});
+
+// mock 이후에 import — vi.mock 호이스팅 효과를 위해 아래에서 import
 // eslint-disable-next-line import/order
 import { JitsiEmbed } from './index';
+// eslint-disable-next-line import/order
+import { probeJitsiExternalApi } from './jitsiHealthCheck';
+
+const probeMock = probeJitsiExternalApi as unknown as Mock;
 
 const ROOM_URL = 'https://jitsi-letscareer.supabin.com/room-abcd';
 
@@ -33,15 +47,30 @@ function renderEmbed(
   return { ...utils, onClose };
 }
 
+/** 프로브 성공 후 JitsiMeeting 이 마운트될 때까지 기다린다. */
+async function renderReady(
+  overrides?: Partial<React.ComponentProps<typeof JitsiEmbed>>,
+) {
+  const utils = renderEmbed(overrides);
+  await screen.findByTestId('jitsi-meeting-mock');
+  return utils;
+}
+
+beforeEach(() => {
+  probeMock.mockReset();
+  // 기본값: 프로브 성공 → 바로 회의실 마운트.
+  probeMock.mockResolvedValue(true);
+});
+
 describe('JitsiEmbed', () => {
-  it('JitsiMeeting에 domain과 roomName이 분리되어 전달된다', () => {
-    renderEmbed();
+  it('프로브 성공 시 JitsiMeeting에 domain과 roomName이 분리되어 전달된다', async () => {
+    await renderReady();
     expect(capturedProps.current?.domain).toBe('jitsi-letscareer.supabin.com');
     expect(capturedProps.current?.roomName).toBe('room-abcd');
   });
 
-  it('configOverwrite에 카메라 허용/480p/desktop FPS 정책이 전달된다', () => {
-    renderEmbed();
+  it('configOverwrite에 카메라 허용/480p/desktop FPS 정책이 전달된다', async () => {
+    await renderReady();
     const config = capturedProps.current?.configOverwrite as Record<
       string,
       unknown
@@ -56,8 +85,8 @@ describe('JitsiEmbed', () => {
     expect(config.toolbarButtons).toContain('camera');
   });
 
-  it('interfaceConfigOverwrite로 Jitsi 로고/워터마크가 모두 숨겨진다', () => {
-    renderEmbed();
+  it('interfaceConfigOverwrite로 Jitsi 로고/워터마크가 모두 숨겨진다', async () => {
+    await renderReady();
     const iface = capturedProps.current?.interfaceConfigOverwrite as Record<
       string,
       unknown
@@ -68,9 +97,9 @@ describe('JitsiEmbed', () => {
     expect(iface.SHOW_WATERMARK_FOR_GUESTS).toBe(false);
   });
 
-  it('onReadyToClose에 onClose가 그대로 연결된다', () => {
+  it('onReadyToClose에 onClose가 그대로 연결된다', async () => {
     const onClose = vi.fn();
-    renderEmbed({ onClose });
+    await renderReady({ onClose });
     const handler = capturedProps.current?.onReadyToClose as () => void;
     handler();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -92,8 +121,8 @@ describe('JitsiEmbed', () => {
     expect(cover?.querySelector('svg')).not.toBeNull();
   });
 
-  it('onApiReady가 종료/실패 계열 진단 이벤트 리스너를 등록한다', () => {
-    renderEmbed();
+  it('onApiReady가 종료/실패 계열 진단 이벤트 리스너를 등록한다', async () => {
+    await renderReady();
     const onApiReady = capturedProps.current?.onApiReady as (api: {
       addListener: (event: string, cb: (p: unknown) => void) => void;
     }) => void;
@@ -103,5 +132,57 @@ describe('JitsiEmbed', () => {
     expect(events).toContain('videoConferenceLeft');
     expect(events).toContain('connectionFailed');
     expect(events).toContain('errorOccurred');
+  });
+
+  describe('failover', () => {
+    it('프로브 실패 시 다음 후보 base로 재등록(registerBaseUrl)한다', async () => {
+      probeMock.mockResolvedValue(false);
+      const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
+
+      renderEmbed({
+        // 후보[0] = 현재(죽은) 도메인, 후보[1] = 다음 healthy 후보
+        baseCandidates: [
+          'https://jitsi-letscareer.supabin.com/',
+          'https://healthy.example.com/',
+        ],
+        registerBaseUrl,
+      });
+
+      await waitFor(() =>
+        expect(registerBaseUrl).toHaveBeenCalledWith(
+          'https://healthy.example.com/',
+        ),
+      );
+      // 아직 회의실은 마운트되지 않는다(재연결 대기).
+      expect(screen.queryByTestId('jitsi-meeting-mock')).toBeNull();
+    });
+
+    it('후보가 없으면 onExhausted를 호출하고 에러 UI를 노출한다', async () => {
+      probeMock.mockResolvedValue(false);
+      const onExhausted = vi.fn();
+
+      renderEmbed({ baseCandidates: [], onExhausted });
+
+      await waitFor(() => expect(onExhausted).toHaveBeenCalledTimes(1));
+      expect(
+        screen.getByText(/회의 서버에 연결할 수 없습니다/),
+      ).toBeInTheDocument();
+    });
+
+    it('이미 시도한 도메인은 재시도하지 않고 소진 처리한다', async () => {
+      probeMock.mockResolvedValue(false);
+      const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
+      const onExhausted = vi.fn();
+
+      // 유일 후보가 현재(죽은) 도메인 → 시도할 새 서버 없음.
+      renderEmbed({
+        baseCandidates: ['https://jitsi-letscareer.supabin.com/'],
+        registerBaseUrl,
+        onExhausted,
+      });
+
+      await waitFor(() => expect(onExhausted).toHaveBeenCalledTimes(1));
+      expect(registerBaseUrl).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/JitsiEmbed/index.test.tsx
+++ b/packages/ui/src/JitsiEmbed/index.test.tsx
@@ -184,5 +184,58 @@ describe('JitsiEmbed', () => {
       await waitFor(() => expect(onExhausted).toHaveBeenCalledTimes(1));
       expect(registerBaseUrl).not.toHaveBeenCalled();
     });
+
+    /** onApiReady 로 넘어온 api mock — addListener 로 등록된 콜백을 캡처한다. */
+    function captureApiListeners() {
+      const listeners: Record<string, () => void> = {};
+      const onApiReady = capturedProps.current?.onApiReady as (api: {
+        addListener: (event: string, cb: () => void) => void;
+      }) => void;
+      onApiReady({
+        addListener: (event, cb) => {
+          listeners[event] = cb;
+        },
+      });
+      return listeners;
+    }
+
+    it('회의 참가 전 connectionFailed는 다음 서버로 failover한다', async () => {
+      const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
+      await renderReady({
+        baseCandidates: [
+          'https://jitsi-letscareer.supabin.com/',
+          'https://healthy.example.com/',
+        ],
+        registerBaseUrl,
+      });
+
+      const listeners = captureApiListeners();
+      listeners['connectionFailed']();
+
+      await waitFor(() =>
+        expect(registerBaseUrl).toHaveBeenCalledWith(
+          'https://healthy.example.com/',
+        ),
+      );
+    });
+
+    it('회의 참가 후 connectionFailed는 서버를 갈아타지 않는다(블립 무시)', async () => {
+      const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
+      await renderReady({
+        baseCandidates: [
+          'https://jitsi-letscareer.supabin.com/',
+          'https://healthy.example.com/',
+        ],
+        registerBaseUrl,
+      });
+
+      const listeners = captureApiListeners();
+      listeners['videoConferenceJoined']();
+      listeners['connectionFailed']();
+
+      // 참가 후 실패는 무시되어야 하므로 재등록이 일어나지 않는다.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(registerBaseUrl).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/JitsiEmbed/index.tsx
+++ b/packages/ui/src/JitsiEmbed/index.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import { JitsiMeeting } from '@jitsi/react-sdk';
 
 import { LetsCareerLogo } from './LetsCareerLogo';
+import { useJitsiConnection } from './useJitsiConnection';
 
 interface JitsiEmbedProps {
   /** 회의실 URL — 외부에서 buildJitsiRoomUrl로 생성해 전달 (셀프호스팅 단일 사용) */
@@ -15,6 +16,15 @@ interface JitsiEmbedProps {
   onClose: () => void;
   /** 좌상단 로고 패널 안(로고 아래)에 함께 묶어 보여줄 내용(예: 세션 타이머). */
   topLeftSlot?: ReactNode;
+  /**
+   * 우선순위 순 jitsi base 후보 (앱별 env). 지정하면 현재 서버 로드 실패 시
+   * 다음 후보로 자동 재등록(failover)한다. 없으면 프로브 후 에러 UI 만 노출.
+   */
+  baseCandidates?: ReadonlyArray<string | undefined>;
+  /** 다음 base 를 BE 에 재등록하는 콜백 (앱별 `PATCH /feedback/{id}/meeting-url`). */
+  registerBaseUrl?: (base: string) => Promise<void>;
+  /** 모든 후보 소진(입장 가능한 서버 없음) 시 호출. */
+  onExhausted?: () => void;
 }
 
 /**
@@ -89,6 +99,36 @@ function parseRoomUrl(roomUrl: string): { domain: string; roomName: string } {
   };
 }
 
+/** 회의실 마운트 전/실패 시 상태 안내 패널 (프로브·재연결·종단 에러). */
+function JitsiConnectionPanel({
+  variant,
+}: {
+  variant: 'probing' | 'reconnecting' | 'failed';
+}) {
+  const message =
+    variant === 'failed'
+      ? '회의 서버에 연결할 수 없습니다.\n잠시 후 다시 시도해 주세요.'
+      : variant === 'reconnecting'
+        ? '다른 회의 서버로 연결하고 있어요…'
+        : '회의실에 연결하고 있어요…';
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-4 text-center">
+        {variant !== 'failed' && (
+          <span
+            aria-hidden
+            className="h-8 w-8 animate-spin rounded-full border-2 border-white/25 border-t-white/80"
+          />
+        )}
+        <p className="whitespace-pre-line text-sm text-neutral-300">
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 /**
  * Jitsi 회의실을 임베드하는 본문 컴포넌트.
  *
@@ -96,8 +136,21 @@ function parseRoomUrl(roomUrl: string): { domain: string; roomName: string } {
  * - hangup / End for all → `onReadyToClose` → 모달 자동 닫힘
  * - 모달 셸은 각 앱에서 자체 BaseModal로 감싸 사용
  */
-export function JitsiEmbed({ roomUrl, onClose, topLeftSlot }: JitsiEmbedProps) {
+export function JitsiEmbed({
+  roomUrl,
+  onClose,
+  topLeftSlot,
+  baseCandidates,
+  registerBaseUrl,
+  onExhausted,
+}: JitsiEmbedProps) {
   const { domain, roomName } = parseRoomUrl(roomUrl);
+  const { status, reportRuntimeError } = useJitsiConnection({
+    roomUrl,
+    baseCandidates,
+    registerBaseUrl,
+    onExhausted,
+  });
 
   return (
     <div className="relative h-full w-full bg-neutral-900">
@@ -120,36 +173,42 @@ export function JitsiEmbed({ roomUrl, onClose, topLeftSlot }: JitsiEmbedProps) {
       >
         닫기
       </button>
-      <JitsiMeeting
-        domain={domain}
-        roomName={roomName}
-        configOverwrite={CONFIG_OVERWRITE}
-        interfaceConfigOverwrite={INTERFACE_CONFIG_OVERWRITE}
-        onReadyToClose={onClose}
-        onApiReady={(api) => {
-          // "일정 시간 후 모달이 저절로 닫힘" 추적용 — readyToClose 를 유발할 수 있는
-          // 종료/실패 계열 이벤트와 사유 payload 를 콘솔에 남긴다. (hangup 인지,
-          // 서버 연결 끊김인지, 강퇴인지 재현 시점 콘솔로 구분)
-          const diagnosticEvents = [
-            'videoConferenceLeft',
-            'connectionFailed',
-            'errorOccurred',
-            'participantKickedOut',
-            'suspendDetected',
-          ];
-          for (const event of diagnosticEvents) {
-            api.addListener(event, (payload: unknown) => {
-              // eslint-disable-next-line no-console
-              console.warn(`[JitsiEmbed] ${event}`, payload);
-            });
-          }
-        }}
-        getIFrameRef={(node) => {
-          node.style.height = '100%';
-          node.style.width = '100%';
-          node.style.border = '0';
-        }}
-      />
+      {status === 'ready' ? (
+        <JitsiMeeting
+          domain={domain}
+          roomName={roomName}
+          configOverwrite={CONFIG_OVERWRITE}
+          interfaceConfigOverwrite={INTERFACE_CONFIG_OVERWRITE}
+          onReadyToClose={onClose}
+          onApiReady={(api) => {
+            // "일정 시간 후 모달이 저절로 닫힘" 추적용 — readyToClose 를 유발할 수 있는
+            // 종료/실패 계열 이벤트와 사유 payload 를 콘솔에 남긴다. (hangup 인지,
+            // 서버 연결 끊김인지, 강퇴인지 재현 시점 콘솔로 구분)
+            const diagnosticEvents = [
+              'videoConferenceLeft',
+              'connectionFailed',
+              'errorOccurred',
+              'participantKickedOut',
+              'suspendDetected',
+            ];
+            for (const event of diagnosticEvents) {
+              api.addListener(event, (payload: unknown) => {
+                // eslint-disable-next-line no-console
+                console.warn(`[JitsiEmbed] ${event}`, payload);
+              });
+            }
+            // 접속 자체가 실패(서버 다운 등)하면 다음 후보 서버로 failover.
+            api.addListener('connectionFailed', () => reportRuntimeError());
+          }}
+          getIFrameRef={(node) => {
+            node.style.height = '100%';
+            node.style.width = '100%';
+            node.style.border = '0';
+          }}
+        />
+      ) : (
+        <JitsiConnectionPanel variant={status} />
+      )}
     </div>
   );
 }

--- a/packages/ui/src/JitsiEmbed/index.tsx
+++ b/packages/ui/src/JitsiEmbed/index.tsx
@@ -197,8 +197,17 @@ export function JitsiEmbed({
                 console.warn(`[JitsiEmbed] ${event}`, payload);
               });
             }
-            // 접속 자체가 실패(서버 다운 등)하면 다음 후보 서버로 failover.
-            api.addListener('connectionFailed', () => reportRuntimeError());
+            // 회의 참가 성공 여부 추적 — 참가 후의 일시적 connectionFailed(네트워크
+            // 블립)에는 서버를 갈아타지 않는다(멘토·멘티 방이 통째로 바뀌는 것 방지).
+            // 참가 전 실패(external_api.js 는 떴지만 회의 백엔드가 죽은 경우)만 다음
+            // 후보 서버로 failover 한다.
+            let joined = false;
+            api.addListener('videoConferenceJoined', () => {
+              joined = true;
+            });
+            api.addListener('connectionFailed', () => {
+              if (!joined) reportRuntimeError();
+            });
           }}
           getIFrameRef={(node) => {
             node.style.height = '100%';

--- a/packages/ui/src/JitsiEmbed/jitsiHealthCheck.ts
+++ b/packages/ui/src/JitsiEmbed/jitsiHealthCheck.ts
@@ -102,3 +102,82 @@ export async function ensureLiveMeetingUrl(
   await options.registerBaseUrl(healthyBase);
   return { ok: true };
 }
+
+/** URL 에서 host 를 안전하게 뽑는다. 파싱 실패면 null. */
+export function safeHost(url: string): string | null {
+  try {
+    return new URL(url).host || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 후보 base 목록에서 **아직 시도하지 않은(triedHosts 에 없는)** 첫 우선순위 base 를 고른다.
+ * 없으면 null. (failover: 실패한 도메인을 제외하고 다음 서버로 넘어갈 때 사용)
+ */
+export function pickNextBase(
+  candidates: ReadonlyArray<string | undefined>,
+  triedHosts: ReadonlySet<string>,
+): string | null {
+  for (const candidate of candidates) {
+    if (!candidate || candidate.trim() === '') continue;
+    const base = normalizeBase(candidate);
+    const host = safeHost(base);
+    if (!host || triedHosts.has(host)) continue;
+    return base;
+  }
+  return null;
+}
+
+/** external_api.js 프로브 타임아웃 (ms) — 스크립트 로드+파싱 여유. */
+const EXTERNAL_API_PROBE_TIMEOUT_MS = 8000;
+
+/**
+ * 대상 도메인에서 Jitsi `external_api.js` 를 실제로 로드해 본다.
+ *
+ * no-cors HEAD 헬스체크(isDomainHealthy)는 opaque 응답이라 503 을 못 거르지만,
+ * 이 프로브는 SDK 가 겪는 것과 **동일한 `<script>` 로드**를 수행하므로 죽은 도메인·
+ * 오타 URL 을 결정적으로 감지한다. `onload` 라도 `window.JitsiMeetExternalAPI` 가
+ * 실제로 정의됐는지까지 확인해, 200 이지만 Jitsi 가 아닌 응답도 실패로 처리한다.
+ *
+ * 성공 시 주입한 `<script>` 를 남겨 SDK(`fetchExternalApi`)가 재사용하게 하고(중복
+ * 주입 방지), 실패 시 죽은 태그를 제거한다(싱글톤 오염 방지).
+ *
+ * @param roomOrBaseUrl 회의실 URL 또는 base URL — host 만 사용한다.
+ */
+export function probeJitsiExternalApi(
+  roomOrBaseUrl: string,
+  timeoutMs: number = EXTERNAL_API_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  if (typeof document === 'undefined') return Promise.resolve(false);
+  const host = safeHost(roomOrBaseUrl);
+  if (!host) return Promise.resolve(false);
+
+  const w = window as typeof window & { JitsiMeetExternalAPI?: unknown };
+  // 이미 로드됨 — SDK 와 동일하게 재사용 가능(External API 는 도메인 무관 클래스).
+  if (w.JitsiMeetExternalAPI) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://${host}/external_api.js`;
+
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      script.onload = null;
+      script.onerror = null;
+      if (!ok) script.remove();
+      resolve(ok);
+    };
+
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    // onload 라도 스크립트가 실제로 API 를 정의했을 때만 성공으로 본다.
+    script.onload = () => finish(!!w.JitsiMeetExternalAPI);
+    script.onerror = () => finish(false);
+    document.head.appendChild(script);
+  });
+}

--- a/packages/ui/src/JitsiEmbed/jitsiProbe.test.ts
+++ b/packages/ui/src/JitsiEmbed/jitsiProbe.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  pickNextBase,
+  probeJitsiExternalApi,
+  safeHost,
+} from './jitsiHealthCheck';
+
+describe('safeHost', () => {
+  it('URL에서 host를 뽑는다', () => {
+    expect(safeHost('https://jitsi-a.example.com/room-x')).toBe(
+      'jitsi-a.example.com',
+    );
+    expect(safeHost('https://jitsi-b.example.com/')).toBe(
+      'jitsi-b.example.com',
+    );
+  });
+
+  it('파싱 불가한 값은 null', () => {
+    expect(safeHost('not-a-url')).toBeNull();
+    expect(safeHost('')).toBeNull();
+  });
+});
+
+describe('pickNextBase', () => {
+  const A = 'https://jitsi-a.example.com/';
+  const B = 'https://jitsi-b.example.com/';
+
+  it('아직 시도하지 않은 첫 우선순위 base를 고른다', () => {
+    expect(pickNextBase([A, B], new Set())).toBe(A);
+  });
+
+  it('시도한 host는 건너뛰고 다음을 고른다', () => {
+    expect(pickNextBase([A, B], new Set(['jitsi-a.example.com']))).toBe(B);
+  });
+
+  it('모두 시도했으면 null', () => {
+    const tried = new Set(['jitsi-a.example.com', 'jitsi-b.example.com']);
+    expect(pickNextBase([A, B], tried)).toBeNull();
+  });
+
+  it('빈 값/undefined 후보는 무시한다', () => {
+    expect(pickNextBase([undefined, '', '  ', B], new Set())).toBe(B);
+  });
+
+  it('trailing slash가 없어도 정규화해서 반환한다', () => {
+    expect(pickNextBase(['https://jitsi-a.example.com'], new Set())).toBe(A);
+  });
+});
+
+describe('probeJitsiExternalApi', () => {
+  afterEach(() => {
+    delete (window as { JitsiMeetExternalAPI?: unknown }).JitsiMeetExternalAPI;
+  });
+
+  it('host를 파싱할 수 없으면 false', async () => {
+    await expect(probeJitsiExternalApi('not-a-url')).resolves.toBe(false);
+  });
+
+  it('이미 external_api가 로드돼 있으면(window.JitsiMeetExternalAPI) 즉시 true', async () => {
+    (window as { JitsiMeetExternalAPI?: unknown }).JitsiMeetExternalAPI =
+      function () {};
+    await expect(
+      probeJitsiExternalApi('https://jitsi-a.example.com/room-x'),
+    ).resolves.toBe(true);
+  });
+
+  it('타임아웃이 지나면 false로 resolve한다(스크립트 미로드)', async () => {
+    // jsdom 은 <script> 를 실제 로드하지 않아 onload/onerror 가 뜨지 않는다.
+    // 짧은 타임아웃을 주면 그 시간 뒤 false 로 귀결된다.
+    await expect(
+      probeJitsiExternalApi('https://jitsi-dead.example.com/room-x', 10),
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/ui/src/JitsiEmbed/useJitsiConnection.ts
+++ b/packages/ui/src/JitsiEmbed/useJitsiConnection.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  pickNextBase,
+  probeJitsiExternalApi,
+  safeHost,
+} from './jitsiHealthCheck';
+
+/**
+ * - `probing`     : external_api.js 로드 프로브 진행 중 (아직 회의실 미마운트)
+ * - `ready`       : 프로브 성공 — 회의실 마운트 가능
+ * - `reconnecting`: 로드/접속 실패 → 다른 서버로 재등록 중 (부모 refetch 대기)
+ * - `failed`      : 후보 소진 또는 재등록 실패 — 종단 에러
+ */
+export type JitsiConnectionStatus =
+  | 'probing'
+  | 'ready'
+  | 'reconnecting'
+  | 'failed';
+
+export interface UseJitsiConnectionOptions {
+  /** BE 가 합성한 회의실 URL. 프로브·마운트 대상. */
+  roomUrl: string;
+  /** 우선순위 순 jitsi base 후보 (앱별 env). 없으면 failover 없이 프로브만. */
+  baseCandidates?: ReadonlyArray<string | undefined>;
+  /**
+   * 다음 base 를 BE 에 재등록하는 콜백 (앱별 `PATCH /feedback/{id}/meeting-url`).
+   * 성공하면 부모가 쿼리 invalidate → refetch → `roomUrl` 이 갱신되어 재프로브된다.
+   * (BE `updateValue` patch-semantics 로 기존 meetingUrl 을 덮어쓴다.)
+   */
+  registerBaseUrl?: (base: string) => Promise<void>;
+  /** 모든 후보 소진(입장 가능한 서버 없음) 시 호출. */
+  onExhausted?: () => void;
+}
+
+/**
+ * Jitsi 회의실 연결 상태 머신 — 사전 프로브 + 서버 failover.
+ *
+ * SDK(`@jitsi/react-sdk`)는 external_api.js 로드 실패를 `console.error` 로 삼키고,
+ * 모듈 전역 `scriptPromise` 싱글톤이 한 번 reject 되면 재사용되어 도메인만 바꿔
+ * remount 해도 재시도가 안 된다. 그래서 **SDK 를 태우기 전에** 우리가 직접 프로브해
+ * 성공한 서버로만 회의실을 마운트하고, 실패하면 다음 후보로 재등록한다.
+ */
+export function useJitsiConnection({
+  roomUrl,
+  baseCandidates,
+  registerBaseUrl,
+  onExhausted,
+}: UseJitsiConnectionOptions) {
+  const [status, setStatus] = useState<JitsiConnectionStatus>('probing');
+
+  // 이미 실패한 도메인 host — roomUrl 이 바뀌어도(재프로브) 유지되어 루프를 막는다.
+  const triedHostsRef = useRef<Set<string>>(new Set());
+  // 재등록 in-flight 가드 — connectionFailed 연속 발화로 중복 failover 방지.
+  const failingRef = useRef(false);
+  // 최신 옵션을 ref 로 잡아 프로브 effect 의존성을 roomUrl 로 고정(배열 리터럴 재생성 무시).
+  const optsRef = useRef({ baseCandidates, registerBaseUrl, onExhausted });
+  optsRef.current = { baseCandidates, registerBaseUrl, onExhausted };
+
+  const failover = useCallback(async (failedUrl: string) => {
+    if (failingRef.current) return;
+    failingRef.current = true;
+    try {
+      const {
+        baseCandidates: candidates,
+        registerBaseUrl: register,
+        onExhausted: exhausted,
+      } = optsRef.current;
+
+      const host = safeHost(failedUrl);
+      if (host) triedHostsRef.current.add(host);
+
+      const next = pickNextBase(candidates ?? [], triedHostsRef.current);
+      if (!next || !register) {
+        setStatus('failed');
+        exhausted?.();
+        return;
+      }
+
+      setStatus('reconnecting');
+      try {
+        // 재등록 성공 → 부모 refetch → roomUrl 갱신 → 아래 effect 가 새 도메인 재프로브.
+        await register(next);
+      } catch {
+        setStatus('failed');
+        exhausted?.();
+      }
+    } finally {
+      failingRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('probing');
+    probeJitsiExternalApi(roomUrl).then((ok) => {
+      if (cancelled) return;
+      if (ok) setStatus('ready');
+      else failover(roomUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [roomUrl, failover]);
+
+  /** 접속 후 런타임 실패(connectionFailed 등) → 동일 failover 경로. */
+  const reportRuntimeError = useCallback(() => {
+    failover(roomUrl);
+  }, [failover, roomUrl]);
+
+  return { status, reportRuntimeError };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,9 @@ export {
 export {
   resolveHealthyJitsiBaseUrl,
   ensureLiveMeetingUrl,
+  probeJitsiExternalApi,
+  pickNextBase,
+  safeHost,
   type EnsureLiveMeetingUrlOptions,
   type EnsureLiveMeetingUrlResult,
 } from './JitsiEmbed/jitsiHealthCheck';


### PR DESCRIPTION
## 배경 (문제)

라이브 피드백에서 "라이브 입장하기"를 눌러도 회의실 모달이 열리지 않고 콘솔에 `Script load error: https://jitsi-letscareer.supabin.com/external_api.js`가 발생했다.

**세 겹의 원인:**
1. **서버 죽음** — `jitsi-letscareer.supabin.com`이 HTTP 503 반환 (`external_api.js`도 503).
2. **헬스체크가 503을 못 걸러냄** — `isDomainHealthy`가 `mode:'no-cors'` HEAD라 응답이 opaque → status를 못 읽어 "응답만 오면 healthy"로 오판 → BASE/FALLBACK failover가 동작 안 함.
3. **SDK가 실패를 숨기고 재시도를 막음** — `@jitsi/react-sdk`는 로드 실패를 `console.error`로만 처리(`onError` prop 없음)하고, 모듈 전역 `scriptPromise` 싱글톤이 한 번 reject되면 재사용돼 도메인만 바꿔 remount해도 재시도가 안 됨.

## 변경 (해결)

초기 서버 선택(`ensureLiveMeetingUrl`)은 그대로 두고, 실행 시 로드 실패를 결정적으로 감지해 다른 서버로 자동 전환하는 **반응형 failover**를 추가했다.

- **사전 프로브** — `JitsiMeeting` 마운트 전에 `external_api.js`를 직접 `<script>`로 로드해 성공/실패를 판정. 성공 시에만 회의창을 띄워 SDK 싱글톤 오염을 막고, 실패 시 SDK를 아예 태우지 않아 깨끗하게 다음 후보로 넘어간다. `onload`라도 `window.JitsiMeetExternalAPI`가 실제 정의됐는지까지 확인.
- **자동 failover** — 실패 → 현재 도메인을 tried에 기록 → 다음 후보 base로 재등록(overwrite PATCH) → 부모 refetch로 새 `meetingUrl` 수신 → 새 도메인 재프로브. 후보 소진 시 무한루프 없이 에러 UI. 접속 후 `connectionFailed`도 동일 경로.
- **백엔드 변경 없음** — BE `updateFeedbackMeetingUrl`이 `EntityUpdateValueUtils.updateValue` patch-semantics라 이미 값이 있어도 overwrite 허용. `meetingRoom`은 고정 유지되어 서버만 갈아타도 멘토·멘티가 같은 방으로 수렴.

이 프로브+failover 하나로 (1) 오타/죽은 URL 초기 선택과 (2) 이미 저장된 stale `meetingUrl` 두 케이스가 동시에 해결된다.

## 변경 파일

| 구분 | 파일 |
|---|---|
| 공용 로직 | `packages/ui/.../JitsiEmbed/jitsiHealthCheck.ts` (probe/pickNextBase/safeHost), `useJitsiConnection.ts` (신규 상태머신), `index.tsx` (프로브 게이트+props), `index.ts` (export) |
| web | `useLiveEntry.ts`, `ReservationInfoSection.tsx`, `LiveFeedbackEntryPage.tsx`, `LiveFeedbackModal.tsx`, `common/modal/JitsiEmbedModal.tsx` |
| mentor | `LiveFeedbackReservationModal.tsx`, `schedule/modal/JitsiEmbedModal.tsx` |
| 테스트 | `index.test.tsx`, `jitsiProbe.test.ts` |

## 검증

- 테스트: packages/ui 38 · mentor 231 · web(feedback·live) 28 — 통과
- typecheck / eslint / prettier — 변경 파일 통과

## 남은 것 (범위 밖)

- 죽은 도메인 `jitsi-letscareer.supabin.com`을 env/Vercel에서 정리 (ops)
- jicofo 진짜 health 엔드포인트로 초기 no-cors 헬스체크 자체를 교체 (인프라, 별도 논의)
- 실제 화면 E2E 수동 확인(죽은 BASE + 정상 FALLBACK으로 입장 시 PATCH 2회 → 정상 서버로 오픈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)