### PR TITLE
fix: Jitsi 헬스체크를 health.json 기반으로 전환 (base 체크 → 실패 시 fallback)

### DIFF
--- a/packages/ui/src/JitsiEmbed/jitsiHealthCheck.test.ts
+++ b/packages/ui/src/JitsiEmbed/jitsiHealthCheck.test.ts
@@ -1,9 +1,28 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import {
   ensureLiveMeetingUrl,
   resolveHealthyJitsiBaseUrl,
 } from './jitsiHealthCheck';
+
+/** base 의 health.json 응답을 흉내내는 fetch mock 을 설치한다. */
+function stubHealthFetch(
+  impl: (url: string) => { ok: boolean; body?: unknown } | Error,
+): Mock {
+  const fetchMock = vi.fn(async (input: string) => {
+    const result = impl(input);
+    if (result instanceof Error) throw result;
+    return {
+      ok: result.ok,
+      json: async () => result.body,
+    } as Response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock as unknown as Mock;
+}
+
+const BASE = 'https://primary.example/';
+const FALLBACK = 'https://fallback.example/';
 
 describe('resolveHealthyJitsiBaseUrl', () => {
   afterEach(() => {
@@ -11,63 +30,71 @@ describe('resolveHealthyJitsiBaseUrl', () => {
     vi.unstubAllGlobals();
   });
 
-  it('여러 도메인이 healthy 하면 우선순위가 가장 높은 base URL(슬래시 보정)을 반환한다', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+  it('base 가 healthy(status HEALTHY)면 base 를 반환한다', async () => {
+    stubHealthFetch(() => ({ ok: true, body: { status: 'HEALTHY' } }));
+    await expect(resolveHealthyJitsiBaseUrl([BASE, FALLBACK])).resolves.toBe(
+      BASE,
     );
-
-    const result = await resolveHealthyJitsiBaseUrl([
-      'https://primary.example',
-      'https://fallback.example',
-    ]);
-
-    expect(result).toBe('https://primary.example/');
-    // 병렬 헬스체크라 모든 후보를 ping 하되, 결과 순서를 보존해 primary 를 고른다.
-    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('첫 번째가 실패하면 두 번째(fallback)로 폴백한다', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('network'))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+  it('base 의 health.json 만 조회하며 캐시 우회 쿼리(?t=)를 붙인다', async () => {
+    const fetchMock = stubHealthFetch(() => ({
+      ok: true,
+      body: { status: 'HEALTHY' },
+    }));
 
-    const result = await resolveHealthyJitsiBaseUrl([
-      'https://primary.example/',
-      'https://fallback.example/',
-    ]);
+    await resolveHealthyJitsiBaseUrl([BASE, FALLBACK]);
 
-    expect(result).toBe('https://fallback.example/');
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('모든 도메인이 실패하면 null 을 반환한다', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')));
-
-    const result = await resolveHealthyJitsiBaseUrl([
-      'https://a.example',
-      'https://b.example',
-    ]);
-
-    expect(result).toBeNull();
-  });
-
-  it('빈/undefined 후보는 건너뛴다', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(new Response(null, { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
-
-    const result = await resolveHealthyJitsiBaseUrl([
-      undefined,
-      '',
-      'https://only.example',
-    ]);
-
-    expect(result).toBe('https://only.example/');
+    const requested = fetchMock.mock.calls[0][0] as string;
+    expect(requested).toMatch(
+      /^https:\/\/primary\.example\/health\.json\?t=\d+$/,
+    );
+    // base 만 확인하고 fallback 은 건드리지 않는다.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('base 가 unhealthy(status 가 HEALTHY 아님)면 fallback 을 반환한다', async () => {
+    stubHealthFetch(() => ({ ok: true, body: { status: 'DOWN' } }));
+    await expect(resolveHealthyJitsiBaseUrl([BASE, FALLBACK])).resolves.toBe(
+      FALLBACK,
+    );
+  });
+
+  it('base 가 503(!ok)이면 fallback 을 반환한다', async () => {
+    stubHealthFetch(() => ({ ok: false }));
+    await expect(resolveHealthyJitsiBaseUrl([BASE, FALLBACK])).resolves.toBe(
+      FALLBACK,
+    );
+  });
+
+  it('base fetch 가 실패(CORS/네트워크)해도 fallback 으로 넘어간다', async () => {
+    stubHealthFetch(() => new TypeError('Failed to fetch'));
+    await expect(resolveHealthyJitsiBaseUrl([BASE, FALLBACK])).resolves.toBe(
+      FALLBACK,
+    );
+  });
+
+  it('base 가 죽었고 fallback 도 없으면 null', async () => {
+    stubHealthFetch(() => ({ ok: false }));
+    await expect(resolveHealthyJitsiBaseUrl([BASE])).resolves.toBeNull();
+  });
+
+  it('후보가 하나도 없으면 fetch 없이 null', async () => {
+    const fetchMock = stubHealthFetch(() => ({
+      ok: true,
+      body: { status: 'HEALTHY' },
+    }));
+    await expect(
+      resolveHealthyJitsiBaseUrl([undefined, '', '  ']),
+    ).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('trailing slash 가 없는 base 도 정규화해서 반환한다', async () => {
+    stubHealthFetch(() => ({ ok: true, body: { status: 'HEALTHY' } }));
+    await expect(
+      resolveHealthyJitsiBaseUrl(['https://primary.example']),
+    ).resolves.toBe(BASE);
   });
 });
 
@@ -78,13 +105,12 @@ describe('ensureLiveMeetingUrl', () => {
   });
 
   it('meetingUrl 이 이미 있으면 헬스체크/등록 없이 ok 를 반환한다', async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = stubHealthFetch(() => ({ ok: true }));
     const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
 
     const result = await ensureLiveMeetingUrl({
       meetingUrl: 'https://meet.example/room-abc',
-      baseCandidates: ['https://primary.example'],
+      baseCandidates: [BASE],
       registerBaseUrl,
     });
 
@@ -94,29 +120,40 @@ describe('ensureLiveMeetingUrl', () => {
   });
 
   it('meetingUrl 이 없으면 healthy base 를 registerBaseUrl 로 등록하고 ok', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
-    );
+    stubHealthFetch(() => ({ ok: true, body: { status: 'HEALTHY' } }));
     const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
 
     const result = await ensureLiveMeetingUrl({
       meetingUrl: null,
-      baseCandidates: ['https://primary.example'],
+      baseCandidates: [BASE],
       registerBaseUrl,
     });
 
     expect(result).toEqual({ ok: true });
-    expect(registerBaseUrl).toHaveBeenCalledWith('https://primary.example/');
+    expect(registerBaseUrl).toHaveBeenCalledWith(BASE);
   });
 
-  it('살아있는 도메인이 없으면 등록하지 않고 no-healthy-domain 을 반환한다', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')));
+  it('base 가 죽으면 fallback 을 등록한다', async () => {
+    stubHealthFetch(() => ({ ok: false }));
     const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
 
     const result = await ensureLiveMeetingUrl({
       meetingUrl: null,
-      baseCandidates: ['https://primary.example'],
+      baseCandidates: [BASE, FALLBACK],
+      registerBaseUrl,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(registerBaseUrl).toHaveBeenCalledWith(FALLBACK);
+  });
+
+  it('base 가 죽었고 fallback 도 없으면 등록하지 않고 no-healthy-domain', async () => {
+    stubHealthFetch(() => ({ ok: false }));
+    const registerBaseUrl = vi.fn().mockResolvedValue(undefined);
+
+    const result = await ensureLiveMeetingUrl({
+      meetingUrl: null,
+      baseCandidates: [BASE],
       registerBaseUrl,
     });
 

--- a/packages/ui/src/JitsiEmbed/jitsiHealthCheck.ts
+++ b/packages/ui/src/JitsiEmbed/jitsiHealthCheck.ts
@@ -21,22 +21,30 @@ function normalizeBase(url: string): string {
 }
 
 /**
- * 단일 도메인이 응답하는지 확인한다.
+ * base 도메인의 `health.json` 을 읽어 **실제 상태**를 판정한다.
  *
- * jitsi 셀프호스팅은 CORS 프리플라이트를 막을 수 있어 `mode: 'no-cors'` 로 보낸다.
- * no-cors 응답은 opaque 라 status 를 읽을 수 없으므로, **fetch 가 reject 되지 않으면
- * (= 네트워크상 도달) healthy** 로 간주한다. 타임아웃·네트워크 오류면 unhealthy.
+ * jitsi-web 컨테이너 nginx 가 서빙하고 watchdog 이 5초 간격으로 갱신하는
+ * `GET {base}/health.json` 을 실측한다. 기존 no-cors HEAD 는 opaque 응답이라
+ * 503 도 healthy 로 통과시켰지만, 여기서는 **응답 본문의 `status` 를 직접 읽어**
+ * 결정적으로 구분한다. fetch·타임아웃·JSON 오류는 모두 unhealthy 로 처리한다.
+ *
+ * 전제: 해당 라우트에 CORS(`Access-Control-Allow-Origin`) 가 열려 있어야 한다.
+ * 미개방 시 브라우저가 CORS 로 fetch 를 막아 reject → false(unhealthy) → fallback 으로
+ * 귀결된다. 즉 CORS 가 열리기 전엔 base 가 항상 무시되므로 배포 전 확인이 필요하다.
+ *
+ * 캐시 우회: 요청마다 `?t=<now>` + `cache: 'no-store'`.
  */
-async function isDomainHealthy(baseUrl: string): Promise<boolean> {
+async function isBaseHealthy(baseUrl: string): Promise<boolean> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
   try {
-    await fetch(normalizeBase(baseUrl), {
-      method: 'HEAD',
-      mode: 'no-cors',
-      signal: controller.signal,
-    });
-    return true;
+    const res = await fetch(
+      `${normalizeBase(baseUrl)}health.json?t=${Date.now()}`,
+      { cache: 'no-store', signal: controller.signal },
+    );
+    if (!res.ok) return false;
+    const body = (await res.json()) as { status?: string } | null;
+    return body?.status === 'HEALTHY';
   } catch {
     return false;
   } finally {
@@ -45,25 +53,27 @@ async function isDomainHealthy(baseUrl: string): Promise<boolean> {
 }
 
 /**
- * 후보 도메인들을 헬스체크해 **우선순위가 가장 높은 healthy base URL** 을 반환한다.
- * 모두 실패하면 null.
+ * 사용할 jitsi base URL 을 고른다 — **base 만 헬스체크**, 실패하면 즉시 fallback.
  *
- * 헬스체크는 서로 독립적이므로 `Promise.all` 로 **병렬** 수행한다(Vercel 베스트 프랙티스).
- * 순차 실행이면 앞 도메인이 죽었을 때 타임아웃만큼 기다린 뒤 다음을 시도해 최악
- * 대기가 후보 수에 비례하지만, 병렬이면 최악 대기가 단일 타임아웃으로 고정된다.
- * 결과 배열은 입력 순서를 보존하므로 가장 먼저 성공한(우선순위 높은) 도메인을 고른다.
+ * `candidates[0]` = 우선(base), 이후 = fallback(우선순위 순). base 의 `health.json` 을
+ * 확인해 healthy 면 base 를, 아니면 **fallback 은 확인하지 않고 그대로** 반환한다.
+ * fallback 까지 죽은 경우는 마운트 직전 `probeJitsiExternalApi`(useJitsiConnection)
+ * 가 external_api.js 로드로 최종 검증해 다음 후보로 failover 한다.
  *
- * @param candidates 우선순위 순 base URL 목록 (빈 값은 무시)
+ * @param candidates 우선순위 순 base URL 목록 (빈 값은 무시). 첫 값이 base.
+ * @returns 사용할 base URL. base 가 죽었고 fallback 도 없으면(=쓸 곳 없음) null.
  */
 export async function resolveHealthyJitsiBaseUrl(
   candidates: ReadonlyArray<string | undefined>,
 ): Promise<string | null> {
   const urls = candidates.filter((u): u is string => !!u && u.trim() !== '');
-  const results = await Promise.all(
-    urls.map(async (url) => ({ url, healthy: await isDomainHealthy(url) })),
-  );
-  const firstHealthy = results.find((r) => r.healthy);
-  return firstHealthy ? normalizeBase(firstHealthy.url) : null;
+  if (urls.length === 0) return null;
+
+  const [base, ...fallbacks] = urls;
+  if (await isBaseHealthy(base)) return normalizeBase(base);
+
+  const fallback = fallbacks[0];
+  return fallback ? normalizeBase(fallback) : null;
 }
 
 export interface EnsureLiveMeetingUrlOptions {
@@ -136,9 +146,10 @@ const EXTERNAL_API_PROBE_TIMEOUT_MS = 8000;
 /**
  * 대상 도메인에서 Jitsi `external_api.js` 를 실제로 로드해 본다.
  *
- * no-cors HEAD 헬스체크(isDomainHealthy)는 opaque 응답이라 503 을 못 거르지만,
- * 이 프로브는 SDK 가 겪는 것과 **동일한 `<script>` 로드**를 수행하므로 죽은 도메인·
- * 오타 URL 을 결정적으로 감지한다. `onload` 라도 `window.JitsiMeetExternalAPI` 가
+ * base 의 `health.json` 헬스체크(isBaseHealthy)는 watchdog 기준 컨테이너 상태만
+ * 알려주고 fallback 은 확인조차 하지 않지만, 이 프로브는 SDK 가 겪는 것과 **동일한
+ * `<script>` 로드**를 실제 브라우저에서 수행하므로 죽은 도메인·오타 URL·fallback 장애를
+ * 마운트 직전 결정적으로 감지한다(최종 게이트). `onload` 라도 `window.JitsiMeetExternalAPI` 가
  * 실제로 정의됐는지까지 확인해, 200 이지만 Jitsi 가 아닌 응답도 실패로 처리한다.
  *
  * 성공 시 주입한 `<script>` 를 남겨 SDK(`fetchExternalApi`)가 재사용하게 하고(중복


### PR DESCRIPTION
## 배경

기존 Jitsi 서버 헬스체크(`isDomainHealthy`)는 `mode: 'no-cors'` HEAD 요청이라 **opaque 응답**이었다. status를 읽을 수 없어 "네트워크 도달 = healthy"로 간주 → **jitsi가 503을 뱉어도 healthy로 통과**시키는 근본 약점이 있었다(이게 external_api.js 로드 실패의 원인).

인프라 팀이 jitsi-web 컨테이너 nginx에 `health.json`(watchdog 5초 간격 갱신)을 추가해줘서, 실제 status를 판독하는 방식으로 전환한다.

## 변경

- `isDomainHealthy`(no-cors HEAD) → **`isBaseHealthy`**: `GET {base}/health.json?t=<now>` + `cache:'no-store'`, 응답 본문의 `status === 'HEALTHY'` 판독
- `resolveHealthyJitsiBaseUrl`: 전체 후보 병렬 체크 → **base만 헬스체크, 실패 시 fallback 즉시 사용**(fallback은 체크하지 않음)
- 마운트 직전 `probeJitsiExternalApi`(useJitsiConnection)는 최종 게이트로 **유지** → fallback 장애까지 external_api.js 실제 로드로 결정적 감지
- 공개 시그니처(`resolveHealthyJitsiBaseUrl`, `ensureLiveMeetingUrl`) 불변 → **호출부 web/mentor 코드 수정 0**

## 동작

| 상황 | 결과 |
| --- | --- |
| base healthy | base 사용 |
| base unhealthy(503/status≠HEALTHY/CORS·네트워크 실패) | fallback 사용 (체크 없이) |
| base 죽음 + fallback 없음 | `no-healthy-domain` |

## 테스트

- `jitsiHealthCheck.test.ts`를 health.json semantics로 교체 + CORS-reject→fallback, 캐시우회 쿼리, base만 fetch 케이스 추가
- JitsiEmbed 스위트 45/45 통과, 변경 파일 타입에러 0, 포맷 통과

## 전제 (배포 조건)

- `health.json` 라우트에 CORS(`Access-Control-Allow-Origin`) 필요 → **확인 완료**: `jitsi-meet.letscareer.co.kr`이 `*`로 응답(www·mentor·localhost 검증)
- fallback은 헬스체크 대상이 아니므로 fallback 도메인엔 health.json 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)