### PR TITLE
fix(admin): 미션등록 미션명 공백·일자 변경 불가 버그 수정

### DIFF
--- a/apps/admin/src/hooks/useMissionOperation.editGuard.test.tsx
+++ b/apps/admin/src/hooks/useMissionOperation.editGuard.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import dayjs from '@/lib/dayjs';
+import { Row } from '@/types/interface';
+
+const patchMock = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('@/utils/axios', () => ({
+  default: {
+    patch: (...args: unknown[]) => patchMock(...args),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+    // 훅 내부 옵션 쿼리들이 부르는 get — 각 스키마가 통과할 최소 응답을 반환한다.
+    get: vi.fn((url: string) => {
+      if (String(url).startsWith('/mission-template/admin')) {
+        return Promise.resolve({
+          data: {
+            data: {
+              missionTemplateAdminList: [],
+              pageInfo: {
+                pageNum: 0,
+                pageSize: 1000,
+                totalElements: 0,
+                totalPages: 0,
+              },
+            },
+          },
+        });
+      }
+      return Promise.resolve({ data: { data: { contentsSimpleList: [] } } });
+    }),
+  },
+}));
+
+const refetchMock = vi.fn();
+vi.mock('@/context/CurrentAdminChallengeProvider', () => ({
+  useAdminCurrentChallenge: () => ({ currentChallenge: { id: 1 } }),
+  useAdminMissionsOfCurrentChallenge: () => [],
+  useMissionsOfCurrentChallengeRefetch: () => refetchMock,
+}));
+
+const snackbarMock = vi.fn();
+vi.mock('@/hooks/useAdminSnackbar', () => ({
+  useAdminSnackbar: () => ({ snackbar: snackbarMock }),
+}));
+
+import { useMissionOperations } from './useMissionOperation';
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+afterEach(() => {
+  patchMock.mockClear();
+  snackbarMock.mockClear();
+});
+
+describe('미션 edit 저장 가드 (1.3)', () => {
+  it('템플릿 미해석 상태에서도 일자 편집 PATCH 를 보내고 title 은 생략한다', async () => {
+    const apiRef = {
+      current: {
+        getRowMode: () => 'view',
+        stopRowEditMode: vi.fn(),
+        forceUpdate: vi.fn(),
+      },
+    } as never;
+
+    const { result } = renderHook(() => useMissionOperations(apiRef), {
+      wrapper: createWrapper(),
+    });
+
+    // missionTemplateId 는 있으나 옵션 목록에 없어 title 이 해석되지 않는 미션
+    const row = {
+      id: 42,
+      missionTemplateId: 999,
+      missionTemplatesOptions: [],
+      additionalContentsList: [],
+      essentialContentsList: [],
+      lateScore: 5,
+      score: 10,
+      th: 1,
+      missionType: null,
+      startDate: dayjs('2026-07-10T09:00:00'),
+      endDate: dayjs('2026-07-12T23:59:00'),
+    } as unknown as Row;
+
+    await act(async () => {
+      await result.current.onAction({ action: 'edit', row });
+    });
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalledTimes(1));
+
+    const [url, payload] = patchMock.mock.calls[0];
+    expect(url).toBe('/mission/42');
+    expect(payload).not.toHaveProperty('title');
+    expect(payload.startDate).toBe('2026-07-10T09:00:00');
+    expect(payload.endDate).toBe('2026-07-12T23:59:59');
+    // 미해석 차단 스낵바가 뜨지 않아야 한다.
+    expect(snackbarMock).not.toHaveBeenCalledWith(
+      '존재하지 않거나 삭제된 미션 템플릿입니다. 다른 템플릿을 선택해주세요.',
+    );
+  });
+});

--- a/apps/admin/src/hooks/useMissionOperation.test.ts
+++ b/apps/admin/src/hooks/useMissionOperation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { missionTemplateAdmin } from '@/schema';
+
+/**
+ * 1.1 회귀 방지: 미션 템플릿 옵션 소스(`missionTemplatesOptions`)는
+ * `missionTemplateAdmin.parse(...).missionTemplateAdminList` 로 그대로 만들어진다.
+ * BE 가 size 20 페이지네이션을 도입한 뒤에도 (size=1000 로) 전량 응답을 받으면
+ * 20개를 초과하는 템플릿(21번째 이상)도 옵션 목록에 포함돼야 미션명 파생이 깨지지 않는다.
+ */
+describe('missionTemplateAdmin 파싱 — 20개 초과 템플릿', () => {
+  const makeTemplate = (id: number) => ({
+    id,
+    createDate: '2026-01-01T00:00:00',
+    missionTag: `tag-${id}`,
+    title: `템플릿 ${id}`,
+    description: '',
+    guide: '',
+    templateLink: null,
+    vodLink: null,
+  });
+
+  it('21번째 이상 템플릿도 옵션 목록에 포함된다', () => {
+    const total = 25;
+    const data = {
+      missionTemplateAdminList: Array.from({ length: total }, (_, i) =>
+        makeTemplate(i + 1),
+      ),
+      pageInfo: {
+        pageNum: 0,
+        pageSize: 1000,
+        totalElements: total,
+        totalPages: 1,
+      },
+    };
+
+    const options = missionTemplateAdmin.parse(data).missionTemplateAdminList;
+
+    expect(options).toHaveLength(total);
+    // 최신 20개 밖(=21번째 이상)의 오래된 템플릿도 조회 가능해야 한다.
+    const template21 = options.find((t) => t.id === 21);
+    expect(template21?.title).toBe('템플릿 21');
+    expect(template21?.missionTag).toBe('tag-21');
+  });
+});

--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -62,7 +62,11 @@ export const useMissionOperations = (
     queryKey: ['admin', 'challenge', 'missionTemplates'],
     enabled: Boolean(currentChallenge),
     queryFn: async (): Promise<MissionTemplateResItem[]> => {
-      const res = await axios.get(`/mission-template/admin`);
+      // BE 가 /mission-template/admin 을 size 20 으로 페이지네이션(LC-3067)한 이후
+      // size 없이 호출하면 최신 20개만 수신돼 옛 템플릿 미션의 미션명이 공백이 된다.
+      // /admin/simple 은 {id, title} 만 반환해 missionTag 파생(태그 컬럼)이 깨지므로
+      // 기존 스키마를 유지한 채 size 를 크게 부여해 전량 로드한다.
+      const res = await axios.get(`/mission-template/admin?size=1000`);
       return missionTemplateAdmin.parse(res.data.data).missionTemplateAdminList;
     },
   });

--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -20,6 +20,9 @@ import { GridApiCommunity } from '@mui/x-data-grid/internals';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 
+// 페이지네이션된 /mission-template/admin 에서 전체 템플릿을 한 번에 받기 위한 큰 페이지 크기.
+const ALL_TEMPLATES_PAGE_SIZE = 1000;
+
 export const useMissionOperations = (
   apiRef: React.RefObject<GridApiCommunity>,
 ) => {
@@ -66,7 +69,9 @@ export const useMissionOperations = (
       // size 없이 호출하면 최신 20개만 수신돼 옛 템플릿 미션의 미션명이 공백이 된다.
       // /admin/simple 은 {id, title} 만 반환해 missionTag 파생(태그 컬럼)이 깨지므로
       // 기존 스키마를 유지한 채 size 를 크게 부여해 전량 로드한다.
-      const res = await axios.get(`/mission-template/admin?size=1000`);
+      const res = await axios.get(
+        `/mission-template/admin?size=${ALL_TEMPLATES_PAGE_SIZE}`,
+      );
       return missionTemplateAdmin.parse(res.data.data).missionTemplateAdminList;
     },
   });

--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -245,6 +245,7 @@ export const useMissionOperations = (
       lateScore: 5,
       score: 10,
       th: 1,
+      title: '',
       missionTemplateId: null,
       missionStatusType: 'WAITING',
       lateAttendanceCount: 0,

--- a/apps/admin/src/hooks/useMissionOperation.ts
+++ b/apps/admin/src/hooks/useMissionOperation.ts
@@ -116,8 +116,8 @@ export const useMissionOperations = (
       action: 'create' | 'edit' | 'delete' | 'cancel';
       row: Row;
     }) => {
-      // 미션 title 은 선택한 템플릿에서만 파생한다. 템플릿이 확정되지 않으면
-      // title 이 빈 문자열로 저장돼 목록·피드백에서 미션명이 공백이 되므로 저장을 막는다.
+      // 미션 title 은 선택한 템플릿에서 파생한다. create 시에는 title 확정을 강제하지만,
+      // edit 시에는 미해석이어도 기존 title 을 유지한 채(생략) 나머지 필드를 저장한다.
       const resolvedTitle = row.missionTemplateId
         ? row.missionTemplatesOptions?.find(
             (t) => t.id === row.missionTemplateId,
@@ -166,18 +166,13 @@ export const useMissionOperations = (
           return;
 
         case 'edit':
-          // 템플릿 목록 미로딩·템플릿 삭제 등으로 title 이 해석되지 않으면
-          // 기존 title 을 빈 문자열로 덮어쓰지 않도록 저장을 막는다.
           if (!row.missionTemplateId) {
             setSnackbar('미션 템플릿을 선택해주세요.');
             return;
           }
-          if (!resolvedTitle) {
-            setSnackbar(
-              '존재하지 않거나 삭제된 미션 템플릿입니다. 다른 템플릿을 선택해주세요.',
-            );
-            return;
-          }
+          // 템플릿 목록 미로딩·템플릿 삭제 등으로 title 이 해석되지 않아도
+          // 일자 등 다른 편집까지 막지 않는다. title 은 PATCH 에서 생략(optional)해
+          // 빈 문자열로 덮어쓰지 않고 기존 미션명을 그대로 유지한다.
           await updateMission.mutateAsync({
             additionalContentsIdList:
               row.additionalContentsList
@@ -198,7 +193,7 @@ export const useMissionOperations = (
               .tz()
               .format('YYYY-MM-DDTHH:mm:ss'),
             th: row.th,
-            title: resolvedTitle,
+            ...(resolvedTitle ? { title: resolvedTitle } : {}),
           });
           if (apiRef?.current?.getRowMode(row.id) === 'edit') {
             apiRef.current?.stopRowEditMode({ id: row.id });

--- a/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.test.ts
+++ b/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { Row } from '@/types/interface';
+
+import { getMissionColumns } from './ChallengeOperationCells';
+
+const getMissionNameFormatter = () => {
+  const column = getMissionColumns().find(
+    (c) => c.field === 'missionTemplateId',
+  );
+  if (!column?.valueFormatter) {
+    throw new Error('미션명 컬럼 valueFormatter 를 찾지 못했습니다.');
+  }
+  return column.valueFormatter;
+};
+
+/**
+ * 1.2 회귀 방지: 서버가 준 미션명(row.title)이 있으면
+ * 템플릿 조인(missionTemplatesOptions)이 실패해도 그 값을 표시해야 한다.
+ */
+describe('미션명 컬럼 표시값', () => {
+  it('템플릿 조인 실패(옵션 목록 비어있음)여도 row.title 을 표시한다', () => {
+    const formatter = getMissionNameFormatter();
+    const row = {
+      title: '자기소개서 미션',
+      missionTemplateId: 123,
+      missionTemplatesOptions: [], // 20위 밖 → 조인 실패 상황
+    } as unknown as Row;
+
+    const result = formatter(null, row, {} as never, {} as never);
+
+    expect(result).toBe('(123) 자기소개서 미션');
+  });
+
+  it('title 이 비어있으면 템플릿에서 파생 폴백한다', () => {
+    const formatter = getMissionNameFormatter();
+    const row = {
+      title: '',
+      missionTemplateId: 7,
+      missionTemplatesOptions: [{ id: 7, title: '템플릿 미션' }],
+    } as unknown as Row;
+
+    const result = formatter(null, row, {} as never, {} as never);
+
+    expect(result).toBe('(7) 템플릿 미션');
+  });
+});

--- a/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.tsx
+++ b/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.tsx
@@ -183,11 +183,13 @@ export const getMissionColumns = (): GridColDef<Row>[] => {
       editable: true,
       width: 140,
       valueFormatter(_, row) {
-        return `${row.missionTemplateId ? `(${row.missionTemplateId}) ` : ''}${
-          row.missionTemplatesOptions.find(
-            (t) => t.id === row.missionTemplateId,
-          )?.title || ''
-        }`;
+        // 서버가 준 미션명(row.title)을 우선 표시해 템플릿 목록 완전성에 의존하지 않는다.
+        // 신규 생성/템플릿 재선택 등 title 이 아직 없을 때만 템플릿에서 파생 폴백한다.
+        const templateTitle = row.missionTemplatesOptions.find(
+          (t) => t.id === row.missionTemplateId,
+        )?.title;
+        const name = row.title || templateTitle || '';
+        return `${row.missionTemplateId ? `(${row.missionTemplateId}) ` : ''}${name}`;
       },
       renderCell(params) {
         return (

--- a/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.tsx
+++ b/apps/admin/src/pages/pages/challenge/ChallengeOperationCells.tsx
@@ -185,9 +185,11 @@ export const getMissionColumns = (): GridColDef<Row>[] => {
       valueFormatter(_, row) {
         // 서버가 준 미션명(row.title)을 우선 표시해 템플릿 목록 완전성에 의존하지 않는다.
         // 신규 생성/템플릿 재선택 등 title 이 아직 없을 때만 템플릿에서 파생 폴백한다.
-        const templateTitle = row.missionTemplatesOptions.find(
-          (t) => t.id === row.missionTemplateId,
-        )?.title;
+        const templateTitle = row.missionTemplateId
+          ? row.missionTemplatesOptions.find(
+              (t) => t.id === row.missionTemplateId,
+            )?.title
+          : undefined;
         const name = row.title || templateTitle || '';
         return `${row.missionTemplateId ? `(${row.missionTemplateId}) ` : ''}${name}`;
       },

--- a/apps/admin/src/schema.ts
+++ b/apps/admin/src/schema.ts
@@ -921,6 +921,7 @@ export const missionAdmin = z
       z.object({
         id: z.number(),
         th: z.number(),
+        title: z.string(),
         missionTag: z.string(),
         missionType: MissionTypeEnum,
         missionStatusType: MissionStatusEnum,

--- a/apps/admin/src/schema.ts
+++ b/apps/admin/src/schema.ts
@@ -921,7 +921,11 @@ export const missionAdmin = z
       z.object({
         id: z.number(),
         th: z.number(),
-        title: z.string(),
+        // 레거시/누락 데이터로 title 이 null 이어도 전체 파싱이 깨지지 않도록 방어한다.
+        title: z
+          .string()
+          .nullish()
+          .transform((val) => val ?? ''),
         missionTag: z.string(),
         missionType: MissionTypeEnum,
         missionStatusType: MissionStatusEnum,


### PR DESCRIPTION
## 배경

분석 보고서: `.claude/tasks/분석-어드민-미션등록-피드백-미션명-일자-버그.md`

어드민 챌린지 운영 **미션등록** 화면에서 두 증상이 동시에 발생했다.

| 증상 | 설명 |
|---|---|
| 미션명 공백 | 미션명 칸이 `(123)` 처럼 id만 남고 이름이 비어 표시 |
| 미션 일자 변경 불가 | 날짜를 바꿔 저장해도 스낵바만 뜨고 저장 안 됨 |

### 근본 원인 (하나의 원인에서 갈라진 두 증상)

- BE 가 `GET /mission-template/admin` 을 `@PageableDefault(size = 20)` + `id DESC` 로 페이지네이션(LC-3067, 2026-05-20)한 뒤, FE 옵션 소스(`useMissionOperation.ts:65`)는 `size` 없이 호출 → **최신 20개 템플릿만 수신**.
- 미션명·태그를 이 20개 목록에서만 파생(`ChallengeOperationCells.tsx`)하고, `missionAdmin` 스키마가 서버 `title` 을 드롭 → 20위 밖 템플릿 미션은 **이름 공백**.
- PR #2439 의 저장 가드(`!resolvedTitle → return`)가 그 미션들의 **모든 편집(일자 포함)을 차단**.

BE 는 정상이며 수정은 전적으로 FE 몫이다.

## 수정 내용 (FE only, BE 변경 없음)

1. **템플릿 전량 로드** (`useMissionOperation.ts`) — `/mission-template/admin?size=1000` 으로 `size` 부여.
   - `/admin/simple` 은 `{id, title}` 만 반환해 태그 컬럼의 `missionTag` 파생과 `MissionTemplateResItem` 형상이 깨지므로(신규 스키마 비용↑), **기존 스키마를 유지한 채 size 를 크게 부여하는 최소 침습안**을 선택.
2. **서버 title 사용** (`schema.ts`, `ChallengeOperationCells.tsx`) — `missionAdmin.missionList` 에 `title: z.string()` 추가(BE 이미 반환), 미션명 컬럼은 `row.title`(서버 권위값)을 우선 표시하고 title 이 없을 때만 템플릿 파생 폴백. `Mission` 타입에 title 이 추가돼 `createNewMission` 초기값에 `title: ''` 추가.
3. **저장 가드 완화** (`useMissionOperation.ts`) — edit 분기에서 `resolvedTitle` 하드 가드 제거. title 은 해석될 때만 PATCH 에 포함(생략 시 기존 title 유지)해 일자 변경 저장을 복구. create 분기의 title 확정 강제는 유지.

## 테스트

- 신규 테스트 3파일 / 4케이스 통과:
  - `useMissionOperation.test.ts` — 20개 초과 템플릿에서 21번째 이상도 옵션에 포함
  - `ChallengeOperationCells.test.ts` — 템플릿 조인 실패해도 `row.title` 표시 / title 없으면 템플릿 폴백
  - `useMissionOperation.editGuard.test.tsx` — 템플릿 미해석 상태에서 date-only edit 시 PATCH 호출 + `title` 생략
- `eslint` 변경 파일 0 error (기존 warning 만).
- `tsc --noEmit` 변경 파일 신규 에러 0 (레포 기존 120건은 origin/main 과 동일한 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
