### PR TITLE
fix(admin): 미션 목록이 전부 안 보이던(No rows) 회귀 수정 — missionAdmin 스키마 내성 [실제 수정]

### DIFF
--- a/apps/admin/src/schema.missionAdmin.test.ts
+++ b/apps/admin/src/schema.missionAdmin.test.ts
@@ -43,10 +43,7 @@ describe('missionAdmin 스키마 - v2 응답 내성', () => {
 
   it('missionType 이 null 인 미션이 섞여도 throw 하지 않고 전량 파싱한다', () => {
     const result = missionAdmin.parse({
-      missionList: [
-        baseMission,
-        { ...baseMission, id: 2, missionType: null },
-      ],
+      missionList: [baseMission, { ...baseMission, id: 2, missionType: null }],
     });
 
     // 두 미션 모두 살아남아 목록이 유지된다(=No rows 회귀 방지).

--- a/apps/admin/src/schema.missionAdmin.test.ts
+++ b/apps/admin/src/schema.missionAdmin.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { missionAdmin } from './schema';
 
-// BE(MissionAdminResponseDto)는 대기(확인중) 인원을 waitingAttendanceCount 로 내려준다.
-// FE 화면(ChallengeOperationAttendances)은 waitingCount 로 읽으므로,
-// missionAdmin 스키마가 필드명을 올바르게 매핑하는지 검증한다.
-describe('missionAdmin 스키마 - waitingCount 필드명 정합', () => {
+// 회귀 방지: FE 가 호출하는 v2 GET /admin/challenge/{id}/mission 응답을
+// missionAdmin 이 파싱한다. 실제 응답에는 다음 두 가지가 존재한다.
+//  1) 대기 인원 JSON 필드명은 waitingCount (waitingAttendanceCount 아님)
+//  2) OT/0회차 등 일부 미션은 missionType 이 null
+// 스키마가 이를 수용하지 못하면 z.array 항목 하나가 배열 전체 parse 를 throw 시켜
+// 미션 목록이 통째로 사라진다("No rows"). 두 경우 모두 파싱돼야 한다.
+describe('missionAdmin 스키마 - v2 응답 내성', () => {
   const baseMission = {
     id: 1,
+    title: '1주차 미션',
     th: 1,
     missionTag: '태그',
     missionType: 'OT',
@@ -15,7 +19,7 @@ describe('missionAdmin 스키마 - waitingCount 필드명 정합', () => {
     attendanceCount: 3,
     lateAttendanceCount: 0,
     wrongAttendanceCount: 0,
-    waitingAttendanceCount: 5,
+    waitingCount: 5,
     applicationCount: 10,
     score: 100,
     lateScore: 50,
@@ -28,23 +32,25 @@ describe('missionAdmin 스키마 - waitingCount 필드명 정합', () => {
     additionalContentsList: null,
   };
 
-  it('BE의 waitingAttendanceCount 를 화면용 waitingCount 로 매핑한다', () => {
-    const result = missionAdmin.parse({ missionList: [baseMission] });
-
-    expect(result.missionList[0].waitingCount).toBe(5);
-  });
-
-  it('waitingAttendanceCount 가 null 이면 waitingCount 도 null 로 유지한다', () => {
+  it('v2 응답의 waitingCount(null 포함)를 그대로 파싱한다', () => {
     const result = missionAdmin.parse({
-      missionList: [{ ...baseMission, waitingAttendanceCount: null }],
+      missionList: [baseMission, { ...baseMission, id: 2, waitingCount: null }],
     });
 
-    expect(result.missionList[0].waitingCount).toBeNull();
+    expect(result.missionList[0].waitingCount).toBe(5);
+    expect(result.missionList[1].waitingCount).toBeNull();
   });
 
-  it('변환 후 결과에는 waitingAttendanceCount 키가 남지 않는다', () => {
-    const result = missionAdmin.parse({ missionList: [baseMission] });
+  it('missionType 이 null 인 미션이 섞여도 throw 하지 않고 전량 파싱한다', () => {
+    const result = missionAdmin.parse({
+      missionList: [
+        baseMission,
+        { ...baseMission, id: 2, missionType: null },
+      ],
+    });
 
-    expect('waitingAttendanceCount' in result.missionList[0]).toBe(false);
+    // 두 미션 모두 살아남아 목록이 유지된다(=No rows 회귀 방지).
+    expect(result.missionList).toHaveLength(2);
+    expect(result.missionList[1].missionType).toBeNull();
   });
 });

--- a/apps/admin/src/schema.ts
+++ b/apps/admin/src/schema.ts
@@ -927,12 +927,16 @@ export const missionAdmin = z
           .nullish()
           .transform((val) => val ?? ''),
         missionTag: z.string(),
-        missionType: MissionTypeEnum,
+        // BE 는 OT/0회차 등 일부 미션의 missionType 을 null 로 내려준다.
+        // 필수 enum 이면 항목 하나가 배열 전체 parse 를 throw 시켜 미션 목록이 전멸한다.
+        missionType: MissionTypeEnum.nullable(),
         missionStatusType: MissionStatusEnum,
         attendanceCount: z.number(),
         lateAttendanceCount: z.number(),
         wrongAttendanceCount: z.number().optional().nullable(),
-        waitingAttendanceCount: z.number().nullable(),
+        // BE 응답(v2 MissionAdminResponseDto)의 실제 JSON 필드명은 waitingCount 다.
+        // waitingAttendanceCount 로 요구하면 키가 없어 parse 가 throw → 미션 전멸.
+        waitingCount: z.number().nullable(),
         applicationCount: z.number(),
         score: z.number(),
         lateScore: z.number(),
@@ -968,12 +972,8 @@ export const missionAdmin = z
   })
   .transform((data) => {
     return {
-      missionList: data.missionList.map(
-        ({ waitingAttendanceCount, ...mission }) => ({
+      missionList: data.missionList.map((mission) => ({
           ...mission,
-          // BE는 대기(확인중) 인원을 waitingAttendanceCount 로 내려주므로
-          // 화면에서 사용하는 waitingCount 로 매핑한다.
-          waitingCount: waitingAttendanceCount,
           startDate: dayjs(mission.startDate),
           endDate: dayjs(mission.endDate),
         }),

--- a/apps/admin/src/schema.ts
+++ b/apps/admin/src/schema.ts
@@ -973,11 +973,10 @@ export const missionAdmin = z
   .transform((data) => {
     return {
       missionList: data.missionList.map((mission) => ({
-          ...mission,
-          startDate: dayjs(mission.startDate),
-          endDate: dayjs(mission.endDate),
-        }),
-      ),
+        ...mission,
+        startDate: dayjs(mission.startDate),
+        endDate: dayjs(mission.endDate),
+      })),
     };
   });
 


### PR DESCRIPTION
## ⚠️ PR #2445 후속 (누락분)
PR #2445 는 병합 타이밍상 **템플릿 방어 커밋만** 들어가고, 정작 미션 목록을 살리는 이 커밋이 빠졌습니다. **이 PR 이 실제 "No rows" 수정입니다.**

## 문제 (브라우저 실검증)
챌린지 운영 → 미션등록에서 **기존 미션이 전부 안 보임("No rows")**. 배포 후에도 지속.

## 근본 원인 (실측)
FE 가 호출하는 v2 `GET /admin/challenge/{id}/mission` 는 **200 + 미션 11개**를 정상 반환하는데, `missionAdmin` 스키마가 실제 응답을 수용 못 해 **`z.array` 항목 하나가 배열 전체 parse 를 throw** → 그리드 "No rows". 두 개의 독립적 parse-breaker:

1. **`missionType: MissionTypeEnum`** (필수) — BE 는 OT/0회차 등 일부 미션의 `missionType` 을 **null** 로 내려줌 (챌린지 337: 11개 중 2개 null). enum 이 null 을 못 받아 throw.
2. **`waitingAttendanceCount`** — 스키마가 이 키를 요구하지만 BE 실제 JSON 필드명은 **`waitingCount`**. `z.number().nullable()` 는 값 null 은 허용해도 **키 누락은 `Required` throw** (main 에 #2444 로 유입된 오판).

## 수정
- `missionType: MissionTypeEnum` → **`.nullable()`**
- `waitingAttendanceCount` → **`waitingCount`** 정합 + transform 매핑 제거
- null 회귀 테스트 추가

## 검증
- **브라우저 실검증(localhost:3001, 챌린지 337)**: 수정 전 "No rows" → 수정 후 미션 **11개 정상 렌더** 확인.
- 테스트 통과.
🤖 Generated with [Claude Code](https://claude.com/claude-code)