### PR TITLE
chore: 멘토 사이드바 예약 현황·참여중인 챌린지 메뉴 임시 숨김

### DIFF
--- a/apps/mentor/src/layout/MentorSidebar.tsx
+++ b/apps/mentor/src/layout/MentorSidebar.tsx
@@ -32,11 +32,15 @@ const navItems: NavItem[] = [
         name: 'LIVE 슬롯 오픈',
         url: '/feedback/live-availability',
       },
-      // 임시 숨김: 예약 현황 메뉴 (추후 복원 예정)
+      // [임시 숨김] 예약 현황 (dusvlf111, 2026-07-17)
+      // 멘티가 신청한 라이브 피드백 예약 내역 페이지(/feedback/live-reservation).
+      // 사이드바 진입점만 가림 — 라우트/페이지는 유지, 추후 복원 시 주석 해제.
       // { type: 'leaf', name: '예약 현황', url: '/feedback/live-reservation' },
     ],
   },
-  // 임시 숨김: 참여중인 챌린지 메뉴 (추후 복원 예정)
+  // [임시 숨김] 참여중인 챌린지 (dusvlf111, 2026-07-17)
+  // 멘토가 참여 중인 챌린지 목록 페이지(/challenges).
+  // 사이드바 진입점만 가림 — 라우트/페이지는 유지, 추후 복원 시 주석 해제.
   // { type: 'leaf', name: '참여중인 챌린지', url: '/challenges' },
   { type: 'leaf', name: '프로필', url: '/profile' },
 ];

--- a/apps/mentor/src/layout/MentorSidebar.tsx
+++ b/apps/mentor/src/layout/MentorSidebar.tsx
@@ -32,10 +32,12 @@ const navItems: NavItem[] = [
         name: 'LIVE 슬롯 오픈',
         url: '/feedback/live-availability',
       },
-      { type: 'leaf', name: '예약 현황', url: '/feedback/live-reservation' },
+      // 임시 숨김: 예약 현황 메뉴 (추후 복원 예정)
+      // { type: 'leaf', name: '예약 현황', url: '/feedback/live-reservation' },
     ],
   },
-  { type: 'leaf', name: '참여중인 챌린지', url: '/challenges' },
+  // 임시 숨김: 참여중인 챌린지 메뉴 (추후 복원 예정)
+  // { type: 'leaf', name: '참여중인 챌린지', url: '/challenges' },
   { type: 'leaf', name: '프로필', url: '/profile' },
 ];
 


### PR DESCRIPTION
## 개요

멘토 앱 사이드바에서 **예약 현황**과 **참여중인 챌린지** 메뉴를 일단 안 보이게 임시 숨김 처리합니다.

## 변경 내용

- `apps/mentor/src/layout/MentorSidebar.tsx`의 `navItems` 배열에서 두 항목 주석 처리
  - `예약 현황` (`/feedback/live-reservation`) — '피드백' 그룹 하위
  - `참여중인 챌린지` (`/challenges`) — 최상위 leaf
- 라우트(`router.tsx`)·페이지·데이터 훅은 그대로 유지 → 추후 복원 시 주석만 해제하면 됨

## 범위 밖

- 직접 URL 접근 차단(라우트 가드)은 이번 범위에 포함하지 않음
- 페이지 컴포넌트/데이터 훅 제거 없음

## 검증

- ✅ `pnpm typecheck` (mentor) — 변경 파일 error 0
- ✅ `pnpm lint` (mentor) — 변경 파일 error 0
- ✅ `prettier --check` — 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)