### PR TITLE
chore: 서류 피드백 REPORT 메뉴 숨김 (1:1 라이브 멘토링 대체 레거시)

### DIFF
--- a/apps/web/src/common/layout/header/NavBar.tsx
+++ b/apps/web/src/common/layout/header/NavBar.tsx
@@ -2,7 +2,11 @@
 
 import { useGetUserAdmin, useIsMentorQuery } from '@/api/user/user';
 import useActiveLink from '@/hooks/useActiveLink';
-import useActiveReportNav from '@/hooks/useActiveReportNav';
+// [레거시 · 삭제 예정] 서류 피드백 REPORT 메뉴 전용 훅.
+// 1:1 라이브 멘토링 상품이 이 흐름을 대체하므로 삭제 대상.
+// 지금은 메뉴 노출만 차단(주석 처리)한 상태이며, 복원이 아니라 '삭제 대기'다.
+// TODO(1:1 라이브 멘토링): 아래 서류 피드백 REPORT 메뉴 블록들과 함께 이 import도 제거할 것.
+// import useActiveReportNav from '@/hooks/useActiveReportNav';
 import { useControlScroll } from '@/hooks/useControlScroll';
 import useProgramCategoryNav from '@/hooks/useProgramCategoryNav';
 import useScrollDirection from '@/hooks/useScrollDirection';
@@ -59,7 +63,10 @@ const NavBar = ({ isLoginPage, disableFixed, ...props }: NavBarProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const activeLink = useActiveLink(pathname);
-  const reportNavList = useActiveReportNav();
+  // [레거시 · 삭제 예정] 서류 피드백 REPORT 메뉴용 목록.
+  // 1:1 라이브 멘토링 상품이 이 흐름을 대체하므로 삭제 대상.
+  // TODO(1:1 라이브 멘토링): 아래 서류 피드백 REPORT 메뉴 블록들과 함께 제거할 것.
+  // const reportNavList = useActiveReportNav();
   const scrollDirection = useScrollDirection(pathname);
   const isMobile = useMediaQuery('(max-width:768px)');
 
@@ -146,17 +153,23 @@ const NavBar = ({ isLoginPage, disableFixed, ...props }: NavBarProps) => {
                   프로그램
                 </GlobalNavItem>
               </SwiperSlide>
-              <SwiperSlide className="!w-auto">
-                <GlobalNavItem
-                  className="text-xsmall14"
-                  active={activeLink === 'REPORT'}
-                  href={
-                    reportNavList.length === 0 ? '#' : reportNavList[0].href
-                  }
-                >
-                  서류 피드백 REPORT
-                </GlobalNavItem>
-              </SwiperSlide>
+              {/*
+                [레거시 · 삭제 예정] 서류 피드백 REPORT 메뉴 (모바일 Swiper)
+                - 1:1 라이브 멘토링 상품이 이 흐름을 대체하므로 삭제 대상.
+                - 지금은 노출만 차단(주석 처리). 복원이 아니라 '삭제 대기' 상태.
+                - TODO(1:1 라이브 멘토링): 이 블록 + reportNavList/useActiveReportNav 함께 제거.
+                <SwiperSlide className="!w-auto">
+                  <GlobalNavItem
+                    className="text-xsmall14"
+                    active={activeLink === 'REPORT'}
+                    href={
+                      reportNavList.length === 0 ? '#' : reportNavList[0].href
+                    }
+                  >
+                    서류 피드백 REPORT
+                  </GlobalNavItem>
+                </SwiperSlide>
+              */}
               <SwiperSlide className="!w-auto">
                 <GlobalNavItem
                   className="text-xsmall14"
@@ -192,14 +205,20 @@ const NavBar = ({ isLoginPage, disableFixed, ...props }: NavBarProps) => {
                 프로그램
                 <span>&nbsp;카테고리</span>
               </GlobalNavItem>
-              <GlobalNavItem
-                className="text-xsmall16"
-                active={activeLink === 'REPORT'}
-                href={reportNavList.length === 0 ? '#' : reportNavList[0].href}
-                subNavList={reportNavList}
-              >
-                서류 피드백 REPORT
-              </GlobalNavItem>
+              {/*
+                [레거시 · 삭제 예정] 서류 피드백 REPORT 메뉴 (데스크톱 GNB)
+                - 1:1 라이브 멘토링 상품이 이 흐름을 대체하므로 삭제 대상.
+                - 지금은 노출만 차단(주석 처리). 복원이 아니라 '삭제 대기' 상태.
+                - TODO(1:1 라이브 멘토링): 이 블록 + reportNavList/useActiveReportNav 함께 제거.
+                <GlobalNavItem
+                  className="text-xsmall16"
+                  active={activeLink === 'REPORT'}
+                  href={reportNavList.length === 0 ? '#' : reportNavList[0].href}
+                  subNavList={reportNavList}
+                >
+                  서류 피드백 REPORT
+                </GlobalNavItem>
+              */}
               <GlobalNavItem
                 className="text-xsmall16"
                 isNew
@@ -263,9 +282,15 @@ const NavBar = ({ isLoginPage, disableFixed, ...props }: NavBarProps) => {
         </SideNavItem>
         <hr className="bg-neutral-80 h-0.5" aria-hidden="true" />
         <SideNavItem href="/program">전체 프로그램</SideNavItem>
-        <SideNavItem href="/review" subNavList={reportNavList}>
-          서류 피드백 REPORT
-        </SideNavItem>
+        {/*
+          [레거시 · 삭제 예정] 서류 피드백 REPORT 메뉴 (사이드 네비)
+          - 1:1 라이브 멘토링 상품이 이 흐름을 대체하므로 삭제 대상.
+          - 지금은 노출만 차단(주석 처리). 복원이 아니라 '삭제 대기' 상태.
+          - TODO(1:1 라이브 멘토링): 이 블록 + reportNavList/useActiveReportNav 함께 제거.
+          <SideNavItem href="/review" subNavList={reportNavList}>
+            서류 피드백 REPORT
+          </SideNavItem>
+        */}
         <SideNavItem href="/library/list" isNew>
           무료 자료집
         </SideNavItem>


### PR DESCRIPTION
## 개요
헤더 네비게이션의 **서류 피드백 REPORT** 메뉴를 노출 차단합니다.

1:1 라이브 멘토링 상품이 이 흐름을 대체할 예정이므로, 단순 임시 숨김이 아니라 **삭제 예약(레거시)** 성격입니다. 그래서 각 블록에 `[레거시 · 삭제 예정]` + `TODO(1:1 라이브 멘토링)` 주석을 남겨, 향후 되살리지 않고 정확히 제거하도록 안내했습니다.

## 변경 사항
`apps/web/src/common/layout/header/NavBar.tsx` 단일 파일:
- 서류 피드백 REPORT 메뉴 3개 표면 주석 처리
  - 모바일 Swiper 탭
  - 데스크톱 GNB
  - 사이드 네비게이션
- 위 3곳을 숨기며 미사용이 되는 `reportNavList`(훅 호출)·`useActiveReportNav` import도 동일 주석으로 처리 → lint/typecheck 미사용 에러 방지 + 삭제 시 한 세트로 제거되도록 명시

## 유지되는 것
- `/report/*` 라우트·페이지는 그대로 (URL 직접 접근 시 정상 동작)
- `Spacer`의 `pathname.startsWith('/report')`, `activeLink`(타 메뉴 공용) 등 메뉴와 무관한 코드

## 검증
- ✅ `tsc --noEmit` (web) 통과
- ✅ `next lint` NavBar.tsx 통과
- ✅ prettier 포맷 확인

> 참고: `@letscareer/ui`의 Storybook 스토리 타입 에러(`@storybook/react-vite` 모듈 누락)는 본 PR과 무관한 기존 이슈입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)