### PR TITLE
feat(admin): 사이드바에 통계(PostHog 임베드) 드롭다운 추가

### DIFF
--- a/apps/admin/src/layout/AdminSidebar.tsx
+++ b/apps/admin/src/layout/AdminSidebar.tsx
@@ -1,8 +1,10 @@
+import { Fragment } from 'react';
 import { ImExit } from 'react-icons/im';
 import { IoIosArrowDown } from 'react-icons/io';
 import { Link } from 'react-router-dom';
 
 import { useIsAdminQuery } from '@/api/user/user';
+import StatsEmbedSection from './StatsEmbedSection';
 
 // 메인 web 으로 이동하는 외부 링크의 호스트.
 // VITE_WEB_URL 미설정 시 admin 자기 자신의 root 로 fallback (안전장치).
@@ -164,46 +166,52 @@ export const AdminSidebar = () => {
     <aside>
       <nav className="sticky left-0 top-0 z-50 flex h-screen w-48 flex-col gap-4 overflow-y-auto bg-[#353535] py-20 pt-4 text-white shadow-xl">
         {navData.map((navSection, index) => (
-          <div key={index}>
-            <div className="flex items-center justify-between border-b border-b-neutral-600 pb-3 pl-4 pr-8">
-              <h3 className="text-xsmall16 font-medium">{navSection.title}</h3>
-              <i className="text-xl text-neutral-600">
-                <IoIosArrowDown />
-              </i>
-            </div>
-            <ul>
-              {navSection.itemList.map((navItem, index) => {
-                const isExternal =
-                  'external' in navItem && navItem.external === true;
-                const className =
-                  'flex items-center gap-1 py-2 pl-6 text-xsmall14 hover:bg-[#2A2A2A]';
-                const content = (
-                  <>
-                    {navItem.name}
-                    {'isExit' in navItem && (
-                      <i>
-                        <ImExit className="translate-y-[1px]" />
-                      </i>
-                    )}
-                  </>
-                );
+          <Fragment key={index}>
+            {/* 통계(PostHog 임베드) 드롭다운은 나가기 바로 위에 둔다. */}
+            {navSection.title === '나가기' && <StatsEmbedSection />}
+            <div>
+              <div className="flex items-center justify-between border-b border-b-neutral-600 pb-3 pl-4 pr-8">
+                <h3 className="text-xsmall16 font-medium">
+                  {navSection.title}
+                </h3>
+                <i className="text-xl text-neutral-600">
+                  <IoIosArrowDown />
+                </i>
+              </div>
+              <ul>
+                {navSection.itemList.map((navItem, index) => {
+                  const isExternal =
+                    'external' in navItem && navItem.external === true;
+                  const className =
+                    'flex items-center gap-1 py-2 pl-6 text-xsmall14 hover:bg-[#2A2A2A]';
+                  const content = (
+                    <>
+                      {navItem.name}
+                      {'isExit' in navItem && (
+                        <i>
+                          <ImExit className="translate-y-[1px]" />
+                        </i>
+                      )}
+                    </>
+                  );
 
-                return (
-                  <li key={index}>
-                    {isExternal ? (
-                      <a href={navItem.url} className={className}>
-                        {content}
-                      </a>
-                    ) : (
-                      <Link to={navItem.url} className={className}>
-                        {content}
-                      </Link>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+                  return (
+                    <li key={index}>
+                      {isExternal ? (
+                        <a href={navItem.url} className={className}>
+                          {content}
+                        </a>
+                      ) : (
+                        <Link to={navItem.url} className={className}>
+                          {content}
+                        </Link>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </Fragment>
         ))}
       </nav>
     </aside>

--- a/apps/admin/src/layout/StatsEmbedSection.tsx
+++ b/apps/admin/src/layout/StatsEmbedSection.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { IoIosArrowDown } from 'react-icons/io';
+import { Link } from 'react-router-dom';
+
+// 통계 항목 — 클릭 시 어드민 콘텐츠 영역에 PostHog 임베드 페이지를 연다.
+const STATS_ITEMS = [{ name: '무료 세미나', url: '/stats/seminar' }] as const;
+
+/**
+ * 사이드바 "통계" 드롭다운(나가기 위, 기본 닫힘).
+ * 열면 항목(무료 세미나 등) 노출, 항목 클릭 시 해당 통계 페이지로 이동한다.
+ */
+const StatsEmbedSection = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between border-b border-b-neutral-600 pb-3 pl-4 pr-8"
+      >
+        <h3 className="text-xsmall16 font-medium">통계</h3>
+        <i
+          className={`text-xl text-neutral-600 transition-transform ${open ? 'rotate-180' : ''}`}
+        >
+          <IoIosArrowDown />
+        </i>
+      </button>
+
+      {open && (
+        <ul>
+          {STATS_ITEMS.map((item) => (
+            <li key={item.name}>
+              <Link
+                to={item.url}
+                className="text-xsmall14 flex items-center gap-1 py-2 pl-6 hover:bg-[#2A2A2A]"
+              >
+                {item.name}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default StatsEmbedSection;

--- a/apps/admin/src/pages/pages/StatsSeminar.tsx
+++ b/apps/admin/src/pages/pages/StatsSeminar.tsx
@@ -1,0 +1,18 @@
+// 무료 세미나 PostHog 임베드 통계 페이지(어드민 콘텐츠 영역). 팀 내부 테스트 지표 확인용.
+const POSTHOG_EMBED_SRC =
+  'https://us.posthog.com/embedded/ixnKagD2dNirQSkSYg3gq66chyTfBg';
+
+const StatsSeminar = () => (
+  <div className="mx-6 my-6">
+    <h1 className="mb-4 text-lg font-semibold">무료 세미나 통계</h1>
+    <iframe
+      title="무료 세미나 PostHog 통계"
+      src={POSTHOG_EMBED_SRC}
+      className="h-[calc(100vh-8rem)] w-full rounded border-0"
+      allowFullScreen
+      sandbox="allow-scripts allow-same-origin allow-popups"
+    />
+  </div>
+);
+
+export default StatsSeminar;

--- a/apps/admin/src/router.tsx
+++ b/apps/admin/src/router.tsx
@@ -5,6 +5,7 @@ import NotFound from './pages/NotFound';
 
 // 무거운 페이지는 lazy로 분리하여 초기 번들 최소화
 const AdminHome = lazy(() => import('./pages/pages/AdminHome'));
+const StatsSeminar = lazy(() => import('./pages/pages/StatsSeminar'));
 const Programs = lazy(() => import('./pages/pages/program/Programs'));
 const ChallengeCreate = lazy(() => import('./pages/pages/ChallengeCreate'));
 const ChallengeEdit = lazy(() => import('./pages/pages/ChallengeEdit'));
@@ -238,6 +239,7 @@ export const router = createBrowserRouter([
     ),
     children: [
       { path: '/', element: withSuspense(<AdminHome />) },
+      { path: '/stats/seminar', element: withSuspense(<StatsSeminar />) },
       { path: '/programs', element: withSuspense(<Programs />) },
       { path: '/challenge/create', element: withSuspense(<ChallengeCreate />) },
       {


### PR DESCRIPTION
## 요약
어드민 사이드바에 팀 내부 분석용 **통계** 드롭다운을 추가합니다. 무료 세미나 관련 PostHog 임베드 대시보드(앵콜/클릭/스크롤 인사이트)를 어드민 안에서 바로 확인하기 위한 내부 도구입니다.

### 변경 사항
- 사이드바 **나가기 위**에 "통계" 드롭다운(기본 닫힘) — `StatsEmbedSection`.
- 드롭다운 항목 "무료 세미나" → `/stats/seminar` 링크.
- `StatsSeminar` 페이지: 어드민 콘텐츠 영역(`AdminShell > Outlet`)에 PostHog 임베드 iframe 풀사이즈 렌더. 라우트 등록.

### 비고
- 팀 내부 지표 확인/메모용입니다. 항목은 `STATS_ITEMS`에 추가하면 확장됩니다(챌린지·마그넷 등).
- 임베드는 PostHog 공유 대시보드 URL. iframe `sandbox="allow-scripts allow-same-origin allow-popups"`.

## 테스트
- [x] ESLint / Prettier 통과, 변경 파일 타입 에러 없음
- [x] 어드민 실제 확인: 통계 드롭다운(기본 닫힘) → 무료 세미나 → /stats/seminar에서 PostHog 대시보드 임베드 정상 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)