### PR TITLE
fix: 앵콜 카드 모바일 레이아웃(figma 19)·빈 상태 헤더 중복 수정

### DIFF
--- a/apps/admin/src/layout/StatsEmbedSection.tsx
+++ b/apps/admin/src/layout/StatsEmbedSection.tsx
@@ -46,4 +46,5 @@ const StatsEmbedSection = () => {
   );
 };
 
+// (재배포 트리거: 병합 커밋 diff=0으로 Vercel skip-build에 걸린 배포를 다시 태우기 위한 no-op 변경)
 export default StatsEmbedSection;

--- a/apps/web/src/domain/seminar/section/SeminarListSection.tsx
+++ b/apps/web/src/domain/seminar/section/SeminarListSection.tsx
@@ -128,7 +128,9 @@ const SeminarListSection = () => {
   return (
     <section className="mx-auto flex w-full max-w-[1120px] flex-col gap-8 md:gap-11">
       <SeminarStatusTabs />
-      {status === 'recruiting' ? <RecruitingHeader /> : <ClosedHeader />}
+      {/* 헤더는 세미나가 있을 때만. 비었을 땐 빈 상태 메시지와 중복되지 않게 숨긴다. */}
+      {programs.length > 0 &&
+        (status === 'recruiting' ? <RecruitingHeader /> : <ClosedHeader />)}
       <SeminarListContent
         status={status}
         isLoading={isLoading || isFetching}

--- a/apps/web/src/domain/seminar/ui/SeminarClosedCard.tsx
+++ b/apps/web/src/domain/seminar/ui/SeminarClosedCard.tsx
@@ -79,6 +79,7 @@ const SeminarClosedCard = ({
       <h3 className="text-xsmall14 md:text-xsmall16 line-clamp-2 font-semibold">
         {programInfo.title}
       </h3>
+      {/* 진행일자 */}
       <div className="flex items-center gap-1.5">
         <span className="text-xxsmall12 md:text-xsmall14 text-neutral-0">
           진행일자
@@ -88,14 +89,14 @@ const SeminarClosedCard = ({
         </span>
       </div>
 
-      {/* 모바일(좁은 2열): 뱃지 위·버튼 풀폭 세로 스택 → 글자 줄바꿈 깨짐 방지. md↑는 좌우 배치. */}
-      <div className="mt-auto flex flex-col items-start gap-2 pt-1 md:flex-row md:items-center md:justify-between">
+      {/* 모집완료 뱃지(자기 줄) → 앵콜 버튼(풀폭) 세로 스택 (figma 19) */}
+      <div className="flex flex-col items-start gap-2">
         <ProgramStatusTag status={PROGRAM_BADGE_STATUS.POST} />
         <button
           type="button"
           onClick={handleEncore}
           aria-pressed={requested}
-          className={`text-xsmall14 rounded-xxs flex w-full items-center justify-center gap-1 whitespace-nowrap px-3.5 py-2 font-medium transition-colors md:w-auto md:justify-start ${requested ? 'bg-primary-80 text-neutral-85' : 'bg-primary-10 text-neutral-20'}`}
+          className={`text-xsmall14 rounded-xxs flex w-full items-center justify-center gap-1 whitespace-nowrap px-3.5 py-2 font-medium transition-colors ${requested ? 'bg-primary-80 text-neutral-85' : 'bg-primary-10 text-neutral-20'}`}
         >
           <MegaphoneIcon className="h-4 w-4" />
           {requested ? '앵콜 요청 완료' : '앵콜 요청하기'}

--- a/apps/web/src/domain/seminar/ui/SeminarClosedCard.tsx
+++ b/apps/web/src/domain/seminar/ui/SeminarClosedCard.tsx
@@ -88,13 +88,14 @@ const SeminarClosedCard = ({
         </span>
       </div>
 
-      <div className="mt-auto flex items-center justify-between gap-2 pt-1">
+      {/* 모바일(좁은 2열): 뱃지 위·버튼 풀폭 세로 스택 → 글자 줄바꿈 깨짐 방지. md↑는 좌우 배치. */}
+      <div className="mt-auto flex flex-col items-start gap-2 pt-1 md:flex-row md:items-center md:justify-between">
         <ProgramStatusTag status={PROGRAM_BADGE_STATUS.POST} />
         <button
           type="button"
           onClick={handleEncore}
           aria-pressed={requested}
-          className={`text-xsmall14 rounded-xxs flex items-center gap-1 px-3.5 py-2 font-medium transition-colors ${requested ? 'bg-primary-80 text-neutral-85' : 'bg-primary-10 text-neutral-20'}`}
+          className={`text-xsmall14 rounded-xxs flex w-full items-center justify-center gap-1 whitespace-nowrap px-3.5 py-2 font-medium transition-colors md:w-auto md:justify-start ${requested ? 'bg-primary-80 text-neutral-85' : 'bg-primary-10 text-neutral-20'}`}
         >
           <MegaphoneIcon className="h-4 w-4" />
           {requested ? '앵콜 요청 완료' : '앵콜 요청하기'}


### PR DESCRIPTION
## 요약
무료 세미나 모집종료 카드의 모바일 레이아웃과 빈 상태 헤더 중복을 수정합니다.
(PR #2464는 재배포 트리거만 머지됐고, 실제 UI 수정은 이 PR입니다.)

## 변경
- **모집종료 카드 모바일(figma 19)**: 진행일자 → `모집 완료` 뱃지(자기 줄) → `앵콜 요청` 버튼(풀폭) **세로 스택**. 좁은 2열에서 뱃지·버튼 글자가 줄바꿈으로 깨지던 문제(figma 17) 해소.
- **빈 상태 헤더 중복(figma 18)**: 모집중/종료 헤더를 **세미나가 있을 때만** 노출 → 빈 상태 안내 메시지와 중복 제거.

## 검증
- [x] 타입체크·ESLint·Prettier 통과
- [x] 로컬 모바일(390px) 실측: 진행일자·모집완료·버튼 모두 1줄, 줄바꿈 없음
- [x] 모집중 빈 상태: 헤더 하나만 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)