### PR TITLE
feat: 결제 페이지 서비스 이용약관 동의 게이트

### DIFF
--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -427,7 +427,7 @@ const PaymentInputContent = () => {
         <button
           // 약관 미동의 시 클릭은 받되(안내 노출) 시각적으로만 비활성 처리한다.
           // 폼 자체가 무효면 기존대로 disabled.
-          className={`next_button border-primary disabled:border-neutral-70 disabled:bg-neutral-70 block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'bg-primary hover:opacity-90' : 'border-neutral-70 bg-neutral-70'}`}
+          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >
@@ -444,7 +444,7 @@ const PaymentInputContent = () => {
           />
         </div>
         <button
-          className={`next_button border-primary disabled:border-neutral-70 disabled:bg-neutral-70 block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'bg-primary hover:opacity-90' : 'border-neutral-70 bg-neutral-70'}`}
+          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -54,6 +54,8 @@ const PaymentInputContent = () => {
   // 서비스 이용약관 동의 상태 + 미동의 결제 시도(안내 노출용) 플래그
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [attemptedPay, setAttemptedPay] = useState(false);
+  // 미동의 클릭마다 버튼을 다시 흔들기 위한 키(값이 바뀌면 애니메이션 재시작).
+  const [shakeKey, setShakeKey] = useState(0);
 
   const { data: programApplicationData } = useProgramStore();
   const { isLoggedIn } = useAuthStore();
@@ -190,6 +192,7 @@ const PaymentInputContent = () => {
     // 클릭은 받되 여기서 가드 — disabled 버튼은 클릭 이벤트가 발생하지 않기 때문).
     if (!agreedToTerms) {
       setAttemptedPay(true);
+      setShakeKey((k) => k + 1); // 누를 때마다 버튼 흔들림 재트리거
       return;
     }
 
@@ -427,7 +430,9 @@ const PaymentInputContent = () => {
         <button
           // 약관 미동의 시 클릭은 받되(안내 노출) 시각적으로만 비활성 처리한다.
           // 폼 자체가 무효면 기존대로 disabled.
-          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'}`}
+          // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
+          key={shakeKey}
+          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >
@@ -444,7 +449,9 @@ const PaymentInputContent = () => {
           />
         </div>
         <button
-          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'}`}
+          // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
+          key={shakeKey}
+          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -448,7 +448,7 @@ const PaymentInputContent = () => {
           // 폼 자체가 무효면 기존대로 disabled.
           // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
           key={shakeKey}
-          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
+          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >
@@ -467,7 +467,7 @@ const PaymentInputContent = () => {
         <button
           // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
           key={shakeKey}
-          className={`next_button border-primary bg-primary block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
+          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
           disabled={!isFormValid}
         >

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -55,8 +55,8 @@ const PaymentInputContent = () => {
   // 서비스 이용약관 동의 상태 + 미동의 결제 시도(안내 노출용) 플래그
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [attemptedPay, setAttemptedPay] = useState(false);
-  // 미동의 클릭마다 버튼을 다시 흔들기 위한 키(값이 바뀌면 애니메이션 재시작).
-  const [shakeKey, setShakeKey] = useState(0);
+  // 미동의 클릭 시 버튼 흔들림 애니메이션 트리거(애니메이션 종료 시 해제).
+  const [isShaking, setIsShaking] = useState(false);
   // 잘못된 접근(새로고침 등) 안내 다이얼로그 노출 여부. window.alert 대체.
   const [invalidAccess, setInvalidAccess] = useState(false);
 
@@ -195,7 +195,7 @@ const PaymentInputContent = () => {
     // 클릭은 받되 여기서 가드 — disabled 버튼은 클릭 이벤트가 발생하지 않기 때문).
     if (!agreedToTerms) {
       setAttemptedPay(true);
-      setShakeKey((k) => k + 1); // 누를 때마다 버튼 흔들림 재트리거
+      setIsShaking(true); // 흔들림 트리거(onAnimationEnd에서 해제)
       return;
     }
 
@@ -226,12 +226,11 @@ const PaymentInputContent = () => {
   ]);
 
   const handleToggleTerms = useCallback(() => {
-    setAgreedToTerms((prev) => {
-      // 동의로 바뀌면 경고를 즉시 감춘다.
-      if (!prev) setAttemptedPay(false);
-      return !prev;
-    });
-  }, []);
+    const nextAgreed = !agreedToTerms;
+    setAgreedToTerms(nextAgreed);
+    // 동의로 바뀌면 경고를 즉시 감춘다.
+    if (nextAgreed) setAttemptedPay(false);
+  }, [agreedToTerms]);
 
   // 폼 자체 유효성(기존) + 약관 동의까지 충족해야 결제 가능.
   const isFormValid =
@@ -446,10 +445,11 @@ const PaymentInputContent = () => {
         <button
           // 약관 미동의 시 클릭은 받되(안내 노출) 시각적으로만 비활성 처리한다.
           // 폼 자체가 무효면 기존대로 disabled.
-          // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
-          key={shakeKey}
-          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
+          // 흔들림은 리마운트(key) 대신 isShaking 클래스 + onAnimationEnd로 처리해
+          // 포커스 유실을 막는다.
+          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${isShaking ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
+          onAnimationEnd={() => setIsShaking(false)}
           disabled={!isFormValid}
         >
           {buttonText}
@@ -465,10 +465,11 @@ const PaymentInputContent = () => {
           />
         </div>
         <button
-          // key 변경 시 리마운트되어 shake 애니메이션이 클릭마다 다시 재생된다.
-          key={shakeKey}
-          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${!canPay && shakeKey ? 'animate-shake motion-reduce:animate-none' : ''}`}
+          // 흔들림은 리마운트(key) 대신 isShaking 클래스 + onAnimationEnd로 처리해
+          // 포커스 유실을 막는다.
+          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${isShaking ? 'animate-shake motion-reduce:animate-none' : ''}`}
           onClick={onPaymentClick}
+          onAnimationEnd={() => setIsShaking(false)}
           disabled={!isFormValid}
         >
           {buttonText}

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -12,7 +12,7 @@ import CouponSection, {
   CouponSectionProps,
 } from '@/domain/program/program-detail/apply/section/CouponSection';
 import MotiveAnswerSection from '@/domain/program/program-detail/apply/section/MotiveAnswerSection';
-import PaymentTermsAgreement from '@/domain/program/program-detail/apply/section/PaymentTermsAgreement';
+import PaymentSubmitSection from '@/domain/program/program-detail/apply/section/PaymentSubmitSection';
 import PriceSection from '@/domain/program/program-detail/apply/section/PriceSection';
 import UserInputSection from '@/domain/program/program-detail/apply/section/UserInputSection';
 import { useInstallmentPayment } from '@/hooks/useInstallmentPayment';
@@ -52,16 +52,11 @@ const PaymentInputContent = () => {
   const [allowNavigation, setAllowNavigation] = useState(false);
   const [nextPath, setNextPath] = useState('');
 
-  // 서비스 이용약관 동의 상태 + 미동의 결제 시도(안내 노출용) 플래그
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const [attemptedPay, setAttemptedPay] = useState(false);
-  // 미동의 클릭 시 버튼 흔들림 애니메이션 트리거(애니메이션 종료 시 해제).
-  const [isShaking, setIsShaking] = useState(false);
   // 잘못된 접근(새로고침 등) 안내 다이얼로그 노출 여부. window.alert 대체.
   const [invalidAccess, setInvalidAccess] = useState(false);
 
   const { data: programApplicationData } = useProgramStore();
-  const { isLoggedIn } = useAuthStore();
+  const { isLoggedIn, isInitialized } = useAuthStore();
   const { isLoading, months, banks } = useInstallmentPayment();
   const patchUserMutation = usePatchUser();
 
@@ -190,15 +185,8 @@ const PaymentInputContent = () => {
     setAllowNavigation(true);
   }, []);
 
+  // 약관 동의 가드·흔들림은 PaymentSubmitSection이 담당한다(동의 시에만 호출됨).
   const onPaymentClick = useCallback(async () => {
-    // 약관 미동의면 결제를 막고 버튼 위 안내를 노출한다(버튼은 disabled가 아니라
-    // 클릭은 받되 여기서 가드 — disabled 버튼은 클릭 이벤트가 발생하지 않기 때문).
-    if (!agreedToTerms) {
-      setAttemptedPay(true);
-      setIsShaking(true); // 흔들림 트리거(onAnimationEnd에서 해제)
-      return;
-    }
-
     try {
       await patchUserMutation.mutateAsync({
         contactEmail: programApplicationData.contactEmail,
@@ -217,7 +205,6 @@ const PaymentInputContent = () => {
       }
     }
   }, [
-    agreedToTerms,
     handleSafeNavigation,
     patchUserMutation,
     programApplicationData.contactEmail,
@@ -225,17 +212,9 @@ const PaymentInputContent = () => {
     totalPrice,
   ]);
 
-  const handleToggleTerms = useCallback(() => {
-    const nextAgreed = !agreedToTerms;
-    setAgreedToTerms(nextAgreed);
-    // 동의로 바뀌면 경고를 즉시 감춘다.
-    if (nextAgreed) setAttemptedPay(false);
-  }, [agreedToTerms]);
-
-  // 폼 자체 유효성(기존) + 약관 동의까지 충족해야 결제 가능.
+  // 폼 자체 유효성(이메일 등). 약관 동의는 PaymentSubmitSection 내부에서 가드한다.
   const isFormValid =
     userInfo.initialized && isValidEmail(userInfo.contactEmail);
-  const canPay = isFormValid && agreedToTerms;
 
   useEffect(() => {
     // 페이지 이탈 시 실행될 함수
@@ -269,12 +248,15 @@ const PaymentInputContent = () => {
   }, [allowNavigation, nextPath, router]);
 
   useEffect(() => {
+    // 인증 스토어 하이드레이션 완료(isInitialized) 전에는 isLoggedIn이 일시적으로
+    // false일 수 있어 정상 사용자에게 오탐이 난다. 초기화 완료 후에만 검증한다.
+    if (!isInitialized) return;
     if (checkInvalidate() || !isLoggedIn) {
       // 기존 window.alert('잘못된 접근입니다.') 를 헤드리스 NoticeDialog(@letscareer/ui)로
       // 대체. 실제 이동/폼 초기화는 다이얼로그 확인(goHome) 시점으로 미룬다.
       setInvalidAccess(true);
     }
-  }, [isLoggedIn]);
+  }, [isInitialized, isLoggedIn]);
 
   const goHome = useCallback(() => {
     initProgramApplicationForm();
@@ -282,13 +264,13 @@ const PaymentInputContent = () => {
   }, [router]);
 
   // 잘못된 접근이면 폼 대신 안내 다이얼로그만 렌더(program 로딩 여부와 무관하게 노출).
+  // 단일 확인 버튼이므로 onConfirm에서만 이동하고, onOpenChange는 상태 동기화만 한다
+  // (양쪽에서 goHome을 부르면 중복 실행됨).
   if (invalidAccess) {
     return (
       <NoticeDialog
-        open
-        onOpenChange={(next) => {
-          if (!next) goHome();
-        }}
+        open={invalidAccess}
+        onOpenChange={setInvalidAccess}
         title="잘못된 접근입니다."
         description="정상적인 경로로 다시 접근해 주세요."
         onConfirm={goHome}
@@ -434,47 +416,11 @@ const PaymentInputContent = () => {
         </div>
       )}
 
-      <div className="shadow-05 fixed bottom-0 left-0 right-0 block rounded-t-lg bg-white px-5 pb-[calc(env(safe-area-inset-bottom)+10px);] pt-3 md:hidden">
-        <div className="mb-3">
-          <PaymentTermsAgreement
-            agreed={agreedToTerms}
-            onToggle={handleToggleTerms}
-            showWarning={attemptedPay}
-          />
-        </div>
-        <button
-          // 약관 미동의 시 클릭은 받되(안내 노출) 시각적으로만 비활성 처리한다.
-          // 폼 자체가 무효면 기존대로 disabled.
-          // 흔들림은 리마운트(key) 대신 isShaking 클래스 + onAnimationEnd로 처리해
-          // 포커스 유실을 막는다.
-          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${isShaking ? 'animate-shake motion-reduce:animate-none' : ''}`}
-          onClick={onPaymentClick}
-          onAnimationEnd={() => setIsShaking(false)}
-          disabled={!isFormValid}
-        >
-          {buttonText}
-        </button>
-      </div>
-
-      <div className="mx-5 hidden md:block">
-        <div className="mb-3">
-          <PaymentTermsAgreement
-            agreed={agreedToTerms}
-            onToggle={handleToggleTerms}
-            showWarning={attemptedPay}
-          />
-        </div>
-        <button
-          // 흔들림은 리마운트(key) 대신 isShaking 클래스 + onAnimationEnd로 처리해
-          // 포커스 유실을 막는다.
-          className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${isShaking ? 'animate-shake motion-reduce:animate-none' : ''}`}
-          onClick={onPaymentClick}
-          onAnimationEnd={() => setIsShaking(false)}
-          disabled={!isFormValid}
-        >
-          {buttonText}
-        </button>
-      </div>
+      <PaymentSubmitSection
+        onSubmit={onPaymentClick}
+        buttonText={buttonText}
+        disabled={!isFormValid}
+      />
     </div>
   );
 };

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -12,6 +12,7 @@ import CouponSection, {
   CouponSectionProps,
 } from '@/domain/program/program-detail/apply/section/CouponSection';
 import MotiveAnswerSection from '@/domain/program/program-detail/apply/section/MotiveAnswerSection';
+import PaymentTermsAgreement from '@/domain/program/program-detail/apply/section/PaymentTermsAgreement';
 import PriceSection from '@/domain/program/program-detail/apply/section/PriceSection';
 import UserInputSection from '@/domain/program/program-detail/apply/section/UserInputSection';
 import { useInstallmentPayment } from '@/hooks/useInstallmentPayment';
@@ -49,6 +50,10 @@ const PaymentInputContent = () => {
 
   const [allowNavigation, setAllowNavigation] = useState(false);
   const [nextPath, setNextPath] = useState('');
+
+  // 서비스 이용약관 동의 상태 + 미동의 결제 시도(안내 노출용) 플래그
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [attemptedPay, setAttemptedPay] = useState(false);
 
   const { data: programApplicationData } = useProgramStore();
   const { isLoggedIn } = useAuthStore();
@@ -181,6 +186,13 @@ const PaymentInputContent = () => {
   }, []);
 
   const onPaymentClick = useCallback(async () => {
+    // 약관 미동의면 결제를 막고 버튼 위 안내를 노출한다(버튼은 disabled가 아니라
+    // 클릭은 받되 여기서 가드 — disabled 버튼은 클릭 이벤트가 발생하지 않기 때문).
+    if (!agreedToTerms) {
+      setAttemptedPay(true);
+      return;
+    }
+
     try {
       await patchUserMutation.mutateAsync({
         contactEmail: programApplicationData.contactEmail,
@@ -199,12 +211,26 @@ const PaymentInputContent = () => {
       }
     }
   }, [
+    agreedToTerms,
     handleSafeNavigation,
     patchUserMutation,
     programApplicationData.contactEmail,
     programApplicationData.programOrderId,
     totalPrice,
   ]);
+
+  const handleToggleTerms = useCallback(() => {
+    setAgreedToTerms((prev) => {
+      // 동의로 바뀌면 경고를 즉시 감춘다.
+      if (!prev) setAttemptedPay(false);
+      return !prev;
+    });
+  }, []);
+
+  // 폼 자체 유효성(기존) + 약관 동의까지 충족해야 결제 가능.
+  const isFormValid =
+    userInfo.initialized && isValidEmail(userInfo.contactEmail);
+  const canPay = isFormValid && agreedToTerms;
 
   useEffect(() => {
     // 페이지 이탈 시 실행될 함수
@@ -391,24 +417,36 @@ const PaymentInputContent = () => {
       )}
 
       <div className="shadow-05 fixed bottom-0 left-0 right-0 block rounded-t-lg bg-white px-5 pb-[calc(env(safe-area-inset-bottom)+10px);] pt-3 md:hidden">
+        <div className="mb-3">
+          <PaymentTermsAgreement
+            agreed={agreedToTerms}
+            onToggle={handleToggleTerms}
+            showWarning={attemptedPay}
+          />
+        </div>
         <button
-          className="next_button border-primary bg-primary disabled:border-neutral-70 disabled:bg-neutral-70 flex w-full flex-1 justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition hover:opacity-90 hover:disabled:opacity-100"
+          // 약관 미동의 시 클릭은 받되(안내 노출) 시각적으로만 비활성 처리한다.
+          // 폼 자체가 무효면 기존대로 disabled.
+          className={`next_button border-primary disabled:border-neutral-70 disabled:bg-neutral-70 block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'bg-primary hover:opacity-90' : 'border-neutral-70 bg-neutral-70'}`}
           onClick={onPaymentClick}
-          disabled={
-            !userInfo.initialized || !isValidEmail(userInfo.contactEmail)
-          }
+          disabled={!isFormValid}
         >
           {buttonText}
         </button>
       </div>
 
       <div className="mx-5 hidden md:block">
+        <div className="mb-3">
+          <PaymentTermsAgreement
+            agreed={agreedToTerms}
+            onToggle={handleToggleTerms}
+            showWarning={attemptedPay}
+          />
+        </div>
         <button
-          className="next_button border-primary bg-primary disabled:border-neutral-70 disabled:bg-neutral-70 block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition hover:opacity-90 hover:disabled:opacity-100"
+          className={`next_button border-primary disabled:border-neutral-70 disabled:bg-neutral-70 block w-full justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'bg-primary hover:opacity-90' : 'border-neutral-70 bg-neutral-70'}`}
           onClick={onPaymentClick}
-          disabled={
-            !userInfo.initialized || !isValidEmail(userInfo.contactEmail)
-          }
+          disabled={!isFormValid}
         >
           {buttonText}
         </button>

--- a/apps/web/src/app/(user)/payment-input/page.tsx
+++ b/apps/web/src/app/(user)/payment-input/page.tsx
@@ -26,6 +26,7 @@ import useProgramStore, {
 } from '@/store/useProgramStore';
 import { isValidEmail } from '@/utils/valid';
 import { AsyncBoundary } from '@/common/boundary/AsyncBoundary';
+import { NoticeDialog } from '@letscareer/ui';
 import { AxiosError } from 'axios';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -56,6 +57,8 @@ const PaymentInputContent = () => {
   const [attemptedPay, setAttemptedPay] = useState(false);
   // 미동의 클릭마다 버튼을 다시 흔들기 위한 키(값이 바뀌면 애니메이션 재시작).
   const [shakeKey, setShakeKey] = useState(0);
+  // 잘못된 접근(새로고침 등) 안내 다이얼로그 노출 여부. window.alert 대체.
+  const [invalidAccess, setInvalidAccess] = useState(false);
 
   const { data: programApplicationData } = useProgramStore();
   const { isLoggedIn } = useAuthStore();
@@ -268,18 +271,31 @@ const PaymentInputContent = () => {
 
   useEffect(() => {
     if (checkInvalidate() || !isLoggedIn) {
-      // eslint-disable-next-line no-console
-      console.log(
-        'checkInvalidate()',
-        checkInvalidate(),
-        'isLoggedIn',
-        isLoggedIn,
-      );
-      alert('잘못된 접근입니다.');
-      router.push('/');
-      initProgramApplicationForm();
+      // 기존 window.alert('잘못된 접근입니다.') 를 헤드리스 NoticeDialog(@letscareer/ui)로
+      // 대체. 실제 이동/폼 초기화는 다이얼로그 확인(goHome) 시점으로 미룬다.
+      setInvalidAccess(true);
     }
-  }, [isLoggedIn, router]);
+  }, [isLoggedIn]);
+
+  const goHome = useCallback(() => {
+    initProgramApplicationForm();
+    router.push('/');
+  }, [router]);
+
+  // 잘못된 접근이면 폼 대신 안내 다이얼로그만 렌더(program 로딩 여부와 무관하게 노출).
+  if (invalidAccess) {
+    return (
+      <NoticeDialog
+        open
+        onOpenChange={(next) => {
+          if (!next) goHome();
+        }}
+        title="잘못된 접근입니다."
+        description="정상적인 경로로 다시 접근해 주세요."
+        onConfirm={goHome}
+      />
+    );
+  }
 
   if (programLoading || !program) {
     return <LoadingContainer />;

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentSubmitSection.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentSubmitSection.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import PaymentTermsAgreement from './PaymentTermsAgreement';
+
+interface PaymentSubmitSectionProps {
+  /** 약관 동의 후 실제 결제 액션 (동의 전에는 호출되지 않는다) */
+  onSubmit: () => void;
+  /** 결제 버튼 라벨 */
+  buttonText: string;
+  /** 폼 무효·위젯 미준비 등 외부 사유로 결제를 막을지 여부 */
+  disabled?: boolean;
+}
+
+/**
+ * 결제 제출 영역 — 서비스 이용약관 동의 체크 + 결제 버튼.
+ * 모바일(하단 고정)·데스크톱(인라인) 레이아웃을 함께 렌더한다.
+ *
+ * 약관 동의 상태·미동의 안내·흔들림 피드백을 내부에서 관리하고, 동의 시에만
+ * onSubmit을 호출한다. /payment-input·/payment 등에서 공통 사용.
+ */
+const PaymentSubmitSection = ({
+  onSubmit,
+  buttonText,
+  disabled = false,
+}: PaymentSubmitSectionProps) => {
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [attemptedPay, setAttemptedPay] = useState(false);
+  const [isShaking, setIsShaking] = useState(false);
+
+  const handleToggleTerms = useCallback(() => {
+    const nextAgreed = !agreedToTerms;
+    setAgreedToTerms(nextAgreed);
+    if (nextAgreed) setAttemptedPay(false); // 동의 시 경고 즉시 감춤
+  }, [agreedToTerms]);
+
+  const handleClick = useCallback(() => {
+    // 약관 미동의면 결제를 막고 안내 노출 + 흔들림. (버튼은 disabled가 아니라
+    // 클릭을 받아 가드 — disabled 버튼은 클릭 이벤트가 발생하지 않기 때문.)
+    if (!agreedToTerms) {
+      setAttemptedPay(true);
+      setIsShaking(true);
+      return;
+    }
+    onSubmit();
+  }, [agreedToTerms, onSubmit]);
+
+  const canPay = agreedToTerms && !disabled;
+
+  // 약관 동의 UI + 결제 버튼 (모바일/데스크톱 공통 렌더).
+  const content = (
+    <>
+      <div className="mb-3">
+        <PaymentTermsAgreement
+          agreed={agreedToTerms}
+          onToggle={handleToggleTerms}
+          showWarning={attemptedPay}
+        />
+      </div>
+      <button
+        // 흔들림은 리마운트(key) 대신 isShaking 클래스 + onAnimationEnd로 처리해
+        // 포커스 유실을 막는다.
+        className={`next_button border-primary bg-primary flex w-full items-center justify-center rounded-md border-2 px-6 py-3 text-lg font-medium text-neutral-100 transition ${canPay ? 'hover:opacity-90' : 'opacity-40'} ${isShaking ? 'animate-shake motion-reduce:animate-none' : ''}`}
+        onClick={handleClick}
+        onAnimationEnd={() => setIsShaking(false)}
+        disabled={disabled}
+      >
+        {buttonText}
+      </button>
+    </>
+  );
+
+  return (
+    <>
+      {/* 모바일: 하단 고정 바 */}
+      <div className="shadow-05 fixed bottom-0 left-0 right-0 block rounded-t-lg bg-white px-5 pb-[calc(env(safe-area-inset-bottom)+10px);] pt-3 md:hidden">
+        {content}
+      </div>
+      {/* 데스크톱: 인라인 */}
+      <div className="mx-5 hidden md:block">{content}</div>
+    </>
+  );
+};
+
+export default PaymentSubmitSection;

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
@@ -24,29 +24,31 @@ const PaymentTermsAgreement = ({
   showWarning,
 }: PaymentTermsAgreementProps) => (
   <div className="flex flex-col gap-1">
-    <button
-      type="button"
-      className="flex items-center gap-2"
-      onClick={onToggle}
-      aria-checked={agreed}
-      role="checkbox"
-    >
+    {/* 토글 버튼(체크박스)과 약관 링크는 형제로 둔다(button 중첩 불가). */}
+    <div className="flex items-center gap-2">
       <span className="text-xsmall14 text-neutral-0">
         [필수]{' '}
         <button
           type="button"
           className="text-primary underline underline-offset-2"
-          onClick={(e) => {
-            e.stopPropagation();
-            window.open(TERMS_URL, '_blank', 'noopener,noreferrer');
-          }}
+          onClick={() =>
+            window.open(TERMS_URL, '_blank', 'noopener,noreferrer')
+          }
         >
           서비스 이용약관
         </button>{' '}
         동의
       </span>
-      <CheckBox checked={agreed} width="w-6" showCheckIcon />
-    </button>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-checked={agreed}
+        role="checkbox"
+        aria-label="서비스 이용약관 동의"
+      >
+        <CheckBox checked={agreed} width="w-6" showCheckIcon />
+      </button>
+    </div>
     {showWarning && !agreed && (
       <p className="text-requirement text-xxsmall12">
         서비스 이용약관에 동의해 주세요.

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
@@ -24,15 +24,20 @@ const PaymentTermsAgreement = ({
   showWarning,
 }: PaymentTermsAgreementProps) => (
   <div className="flex flex-col gap-1">
-    {/* 토글 버튼(체크박스)과 약관 링크는 형제로 둔다(button 중첩 불가). */}
+    {/* 토글 버튼(체크박스)과 약관 링크는 형제로 둔다(button 중첩 불가).
+        텍스트 영역도 클릭하면 토글되도록 하고, 링크 클릭은 전파를 막아 약관만 연다. */}
     <div className="flex items-center gap-2">
-      <span className="text-xsmall14 text-neutral-0">
+      <span
+        className="text-xsmall14 text-neutral-0 cursor-pointer select-none"
+        onClick={onToggle}
+      >
         [필수]{' '}
         <a
           href={TERMS_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="text-primary underline underline-offset-2"
+          onClick={(e) => e.stopPropagation()}
         >
           서비스 이용약관
         </a>{' '}

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import CheckBox from '@/common/box/CheckBox';
+
+// 회원가입 동의(AgreementSection)·footer와 동일한 서비스 이용약관 노션 URL.
+const TERMS_URL =
+  'https://letsintern.notion.site/251208-2c35e77cbee1800bb2b5cfbd4c2f1525?pvs=21';
+
+interface PaymentTermsAgreementProps {
+  agreed: boolean;
+  onToggle: () => void;
+  /** 미동의 상태에서 결제를 시도해 안내를 노출할지 여부 */
+  showWarning: boolean;
+}
+
+/**
+ * 결제 버튼 위 서비스 이용약관 동의 체크박스.
+ * 미동의 상태로 결제를 누르면 showWarning=true 로 안내 문구를 띄운다.
+ * "서비스 이용약관" 클릭 시 노션 약관 페이지를 새 창으로 연다.
+ */
+const PaymentTermsAgreement = ({
+  agreed,
+  onToggle,
+  showWarning,
+}: PaymentTermsAgreementProps) => (
+  <div className="flex flex-col gap-1">
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        className="flex items-center gap-2"
+        onClick={onToggle}
+        aria-checked={agreed}
+        role="checkbox"
+      >
+        <CheckBox checked={agreed} width="w-6" showCheckIcon />
+        <span className="text-xsmall14 text-neutral-0">
+          [필수]{' '}
+          <button
+            type="button"
+            className="text-primary underline underline-offset-2"
+            onClick={(e) => {
+              e.stopPropagation();
+              window.open(TERMS_URL, '_blank', 'noopener,noreferrer');
+            }}
+          >
+            서비스 이용약관
+          </button>{' '}
+          동의
+        </span>
+      </button>
+    </div>
+    {showWarning && !agreed && (
+      <p className="text-requirement text-xxsmall12 pl-8">
+        서비스 이용약관에 동의해 주세요.
+      </p>
+    )}
+  </div>
+);
+
+export default PaymentTermsAgreement;

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
@@ -24,33 +24,31 @@ const PaymentTermsAgreement = ({
   showWarning,
 }: PaymentTermsAgreementProps) => (
   <div className="flex flex-col gap-1">
-    <div className="flex items-center gap-2">
-      <button
-        type="button"
-        className="flex items-center gap-2"
-        onClick={onToggle}
-        aria-checked={agreed}
-        role="checkbox"
-      >
-        <CheckBox checked={agreed} width="w-6" showCheckIcon />
-        <span className="text-xsmall14 text-neutral-0">
-          [필수]{' '}
-          <button
-            type="button"
-            className="text-primary underline underline-offset-2"
-            onClick={(e) => {
-              e.stopPropagation();
-              window.open(TERMS_URL, '_blank', 'noopener,noreferrer');
-            }}
-          >
-            서비스 이용약관
-          </button>{' '}
-          동의
-        </span>
-      </button>
-    </div>
+    <button
+      type="button"
+      className="flex items-center gap-2"
+      onClick={onToggle}
+      aria-checked={agreed}
+      role="checkbox"
+    >
+      <span className="text-xsmall14 text-neutral-0">
+        [필수]{' '}
+        <button
+          type="button"
+          className="text-primary underline underline-offset-2"
+          onClick={(e) => {
+            e.stopPropagation();
+            window.open(TERMS_URL, '_blank', 'noopener,noreferrer');
+          }}
+        >
+          서비스 이용약관
+        </button>{' '}
+        동의
+      </span>
+      <CheckBox checked={agreed} width="w-6" showCheckIcon />
+    </button>
     {showWarning && !agreed && (
-      <p className="text-requirement text-xxsmall12 pl-8">
+      <p className="text-requirement text-xxsmall12">
         서비스 이용약관에 동의해 주세요.
       </p>
     )}

--- a/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
+++ b/apps/web/src/domain/program/program-detail/apply/section/PaymentTermsAgreement.tsx
@@ -28,15 +28,14 @@ const PaymentTermsAgreement = ({
     <div className="flex items-center gap-2">
       <span className="text-xsmall14 text-neutral-0">
         [필수]{' '}
-        <button
-          type="button"
+        <a
+          href={TERMS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
           className="text-primary underline underline-offset-2"
-          onClick={() =>
-            window.open(TERMS_URL, '_blank', 'noopener,noreferrer')
-          }
         >
           서비스 이용약관
-        </button>{' '}
+        </a>{' '}
         동의
       </span>
       <button

--- a/packages/config/tailwind/preset.js
+++ b/packages/config/tailwind/preset.js
@@ -216,6 +216,12 @@ const preset = {
           '25%': { transform: 'rotate(-6deg)' },
           '75%': { transform: 'rotate(6deg)' },
         },
+        // 거부 피드백용 은은한 좌우 흔들림(예: 비활성 버튼 클릭)
+        shake: {
+          '0%, 100%': { transform: 'translateX(0)' },
+          '20%, 60%': { transform: 'translateX(-4px)' },
+          '40%, 80%': { transform: 'translateX(4px)' },
+        },
       },
       animation: {
         'live-infinite-scroll-desktop':
@@ -227,6 +233,7 @@ const preset = {
         'slide-in-right': 'slide-in-right 0.2s ease-out',
         'infinite-scroll': 'infinite-scroll 40s linear infinite',
         wobble: 'wobble 0.4s ease-in-out',
+        shake: 'shake 0.4s ease-in-out',
       },
     },
     borderRadius: {

--- a/packages/ui/src/AlertDialog/AlertDialog.stories.tsx
+++ b/packages/ui/src/AlertDialog/AlertDialog.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ConfirmDialog } from './ConfirmDialog';
 import { EditConfirmDialog } from './EditConfirmDialog';
 import { DangerConfirmDialog } from './DangerConfirmDialog';
+import { NoticeDialog } from './NoticeDialog';
 
 const TRIGGER_CLASSES =
   'inline-flex h-10 items-center justify-center rounded-sm bg-primary px-4 text-xsmall14 font-medium text-white transition-colors hover:bg-primary-hover';
@@ -40,6 +41,28 @@ export const Default: Story = {
           onOpenChange={setOpen}
           title="변경 사항을 저장할까요?"
           description="지금까지 입력한 내용이 저장됩니다."
+          onConfirm={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+// Layer 1 — NoticeDialog (단일 확인 버튼, window.alert 대체)
+export const Notice: Story = {
+  args: DUMMY_ARGS,
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <button className={TRIGGER_CLASSES} onClick={() => setOpen(true)}>
+          안내 열기
+        </button>
+        <NoticeDialog
+          open={open}
+          onOpenChange={setOpen}
+          title="잘못된 접근입니다."
+          description="정상적인 경로로 다시 접근해 주세요."
           onConfirm={() => setOpen(false)}
         />
       </>

--- a/packages/ui/src/AlertDialog/NoticeDialog.tsx
+++ b/packages/ui/src/AlertDialog/NoticeDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as React from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+} from './primitives';
+
+export interface NoticeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** 단일 확인 버튼 라벨 (기본 '확인') */
+  confirmLabel?: string;
+  /** 확인 클릭 시 실행 (예: 홈으로 이동). 미지정 시 닫기만 한다. */
+  onConfirm?: () => void;
+}
+
+const OVERLAY_CLASSES =
+  'fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-fade-in';
+
+const CONTENT_CLASSES =
+  'fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-04 focus:outline-none data-[state=open]:animate-fade-in';
+
+const TITLE_CLASSES = 'text-small18 font-semibold text-neutral-0';
+const DESCRIPTION_CLASSES = 'mt-2 text-xsmall14 text-neutral-30';
+
+const ACTION_CLASSES =
+  'inline-flex h-10 items-center justify-center rounded-sm bg-primary px-4 text-xsmall14 font-medium text-white transition-colors hover:bg-primary-hover';
+
+/**
+ * 단일 확인 버튼 안내 다이얼로그 (Layer 1).
+ *
+ * 선택(확인/취소)이 없는 순수 알림용. `window.alert` 대체로 쓴다.
+ * ConfirmDialog와 달리 취소 버튼이 없어 "잘못된 접근" 등 강제 안내에 적합.
+ */
+export function NoticeDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = '확인',
+  onConfirm,
+}: NoticeDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogPortal>
+        <AlertDialogOverlay className={OVERLAY_CLASSES} />
+        <AlertDialogContent className={CONTENT_CLASSES}>
+          <AlertDialogTitle className={TITLE_CLASSES}>{title}</AlertDialogTitle>
+          {description ? (
+            <AlertDialogDescription className={DESCRIPTION_CLASSES}>
+              {description}
+            </AlertDialogDescription>
+          ) : null}
+          <div className="mt-6 flex justify-end">
+            <AlertDialogAction className={ACTION_CLASSES} onClick={onConfirm}>
+              {confirmLabel}
+            </AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialogPortal>
+    </AlertDialog>
+  );
+}

--- a/packages/ui/src/AlertDialog/index.tsx
+++ b/packages/ui/src/AlertDialog/index.tsx
@@ -76,6 +76,10 @@ export {
 export { ConfirmDialog } from './ConfirmDialog';
 export type { ConfirmDialogProps, ConfirmVariant } from './ConfirmDialog';
 
+// Layer 1 — NoticeDialog (단일 확인 버튼, window.alert 대체)
+export { NoticeDialog } from './NoticeDialog';
+export type { NoticeDialogProps } from './NoticeDialog';
+
 // Layer 2 — preset 컴포넌트
 export { EditConfirmDialog } from './EditConfirmDialog';
 export type { EditConfirmDialogProps } from './EditConfirmDialog';


### PR DESCRIPTION
## 요약
`/payment-input` 결제 페이지에 **서비스 이용약관 동의 게이트**를 추가하고, 관련 UX·에러를 정리합니다.

## 변경
1. **약관 동의 게이트**: 결제 버튼 위 `[필수] 서비스 이용약관 동의` 체크박스(텍스트 왼쪽·체크박스 오른쪽). "서비스 이용약관" 클릭 시 노션 약관 새 창(회원가입 동의·footer와 동일 URL).
2. **미동의 시**: 결제 버튼을 **브랜드색 + opacity-40**(뿌옇게)로 비활성 표현. 클릭하면 버튼 위 안내 노출 + **버튼 흔들림 피드백**(0.4s, reduced-motion 존중).
3. **잘못된 접근 alert 커스텀**: `window.alert('잘못된 접근입니다.')` → 헤드리스 **`NoticeDialog`**(@letscareer/ui 신규, Radix primitives 재사용, 단일 확인 버튼). 확인 시 폼 초기화 후 홈 이동.
4. **버그픽스**: 약관 토글 button 안에 링크 button이 중첩돼 hydration 에러 → 형제로 분리.

## 신규 공용 컴포넌트
- `@letscareer/ui`의 `NoticeDialog` — 단일 확인 안내 다이얼로그(window.alert 대체용). index export + Storybook 스토리 추가. 동일 alert가 있는 나머지 9곳은 이번 스코프 밖으로 보존(후속 이관).

## 구현 노트
- 결제 버튼을 `disabled`로 두지 않고 **클릭을 받아 핸들러에서 가드**(disabled 버튼은 클릭 이벤트 미발생 → "클릭 시 안내"가 불가). 폼 자체 무효 시에만 실제 disabled.
- shake는 tailwind preset에 추가(기존 wobble과 동일 방식, `key` 변경으로 클릭마다 재생).

## 검증
- [x] 타입체크·ESLint·Prettier 통과 (ui 패키지 storybook 타입에러 6건은 main 선행 이슈)
- [x] NoticeDialog: 로컬 브라우저 실측(다이얼로그 렌더 → 확인 → 홈 이동)
- [ ] 약관 게이트/흔들림: 로그인+결제 스토어 진입 조건이라 Vercel 프리뷰에서 실제 결제 플로우 확인 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)