### PR TITLE
fix: 멘토 서면 피드백 멘티 선택·사전질문 노출 수정

### DIFF
--- a/apps/mentor/src/api/challenge/challengeSchema.ts
+++ b/apps/mentor/src/api/challenge/challengeSchema.ts
@@ -180,6 +180,8 @@ export const challengeMissionFeedbackSchema = z.object({
 export const feedbackAttendanceSchema = z.object({
   attendanceDetailVo: z.object({
     feedback: z.string().nullish(),
+    // 멘티 사전 질문 — BE 추가 예정. 미배포 시 undefined 라 forward-compatible.
+    preQuestion: z.string().nullish(),
   }),
 });
 

--- a/apps/mentor/src/pages/feedback-management/FeedbackManagementPage.tsx
+++ b/apps/mentor/src/pages/feedback-management/FeedbackManagementPage.tsx
@@ -94,6 +94,7 @@ const FeedbackManagementPage = () => {
         challengeTitle: row.source.challengeTitle,
         missionId: row.source.missionId,
         missionTh: row.source.missionTh,
+        attendanceId: row.source.attendanceId,
       });
       return;
     }
@@ -143,6 +144,7 @@ const FeedbackManagementPage = () => {
           missionId={feedbackModal.missionId}
           challengeTitle={feedbackModal.challengeTitle}
           missionTh={feedbackModal.missionTh}
+          initialAttendanceId={feedbackModal.initialAttendanceId}
         />
       ) : (
         <FeedbackModal
@@ -152,6 +154,7 @@ const FeedbackManagementPage = () => {
           missionId={feedbackModal.missionId}
           challengeTitle={feedbackModal.challengeTitle}
           missionTh={feedbackModal.missionTh}
+          initialAttendanceId={feedbackModal.initialAttendanceId}
         />
       )}
 

--- a/apps/mentor/src/pages/feedback-management/__tests__/useMergedFeedbackRows.test.ts
+++ b/apps/mentor/src/pages/feedback-management/__tests__/useMergedFeedbackRows.test.ts
@@ -201,6 +201,8 @@ describe('useMergedFeedbackRows', () => {
       missionId: 1001,
       missionTh: 1,
       challengeTitle: '기필코 경험정리 챌린지 21기',
+      // 클릭한 멘티 본인 상세 진입용 출석 id (row id 'written-1-1001-11'의 11).
+      attendanceId: 11,
     });
     expect(row?.thLabel).toBe('1회차');
   });

--- a/apps/mentor/src/pages/feedback-management/hooks/useFeedbackManagement.ts
+++ b/apps/mentor/src/pages/feedback-management/hooks/useFeedbackManagement.ts
@@ -11,6 +11,8 @@ interface FeedbackModalState {
   missionId: number;
   challengeTitle?: string;
   missionTh?: number;
+  /** 진입 시 초기 선택할 멘티의 출석 id (없으면 첫 멘티). */
+  initialAttendanceId?: number | null;
 }
 
 /**
@@ -51,6 +53,7 @@ export function useFeedbackManagement() {
     challengeTitle?: string;
     missionId: number;
     missionTh: number;
+    attendanceId?: number | null;
   }) => {
     setFeedbackModal({
       isOpen: true,
@@ -58,6 +61,7 @@ export function useFeedbackManagement() {
       missionId: params.missionId,
       challengeTitle: params.challengeTitle,
       missionTh: params.missionTh,
+      initialAttendanceId: params.attendanceId ?? null,
     });
   };
 

--- a/apps/mentor/src/pages/feedback-management/hooks/useMergedFeedbackRows.ts
+++ b/apps/mentor/src/pages/feedback-management/hooks/useMergedFeedbackRows.ts
@@ -326,6 +326,8 @@ export function useMergedFeedbackRows(
               missionId: mission.missionId,
               missionTh: mission.th,
               challengeTitle: challenge.title ?? '챌린지',
+              // 클릭한 멘티 본인 상세로 진입하기 위한 출석 id (index 0 폴백 방지).
+              attendanceId: mentee.id,
             },
           });
         });

--- a/apps/mentor/src/pages/feedback-management/types.ts
+++ b/apps/mentor/src/pages/feedback-management/types.ts
@@ -65,6 +65,8 @@ export interface FeedbackRow {
         missionId: number;
         missionTh: number;
         challengeTitle: string;
+        /** 클릭한 멘티의 출석 id — 모달 초기 선택용 (미제출자는 null) */
+        attendanceId: number | null;
       }
     | {
         type: 'live';

--- a/apps/mentor/src/pages/feedback/FeedbackModal.tsx
+++ b/apps/mentor/src/pages/feedback/FeedbackModal.tsx
@@ -34,6 +34,7 @@ interface FeedbackModalProps {
   missionId: number;
   challengeTitle?: string;
   missionTh?: number;
+  initialAttendanceId?: number | null;
 }
 
 const FeedbackModal = ({
@@ -43,6 +44,7 @@ const FeedbackModal = ({
   missionId,
   challengeTitle,
   missionTh,
+  initialAttendanceId,
 }: FeedbackModalProps) => {
   const {
     selectedIndex,
@@ -50,6 +52,7 @@ const FeedbackModal = ({
     editorContent,
     setEditorContent,
     currentMentee,
+    preQuestion,
     isReadOnly,
     isAbsent,
     attendanceList,
@@ -59,7 +62,13 @@ const FeedbackModal = ({
     editorKey,
     confirmModal,
     handleConfirmResult,
-  } = useFeedbackModal({ isOpen, onClose, challengeId, missionId });
+  } = useFeedbackModal({
+    isOpen,
+    onClose,
+    challengeId,
+    missionId,
+    initialAttendanceId,
+  });
 
   const { hasPrevMentee, hasNextMentee, handlePrevMentee, handleNextMentee } =
     useMenteeNavigation({
@@ -169,6 +178,7 @@ const FeedbackModal = ({
             mentee={currentMentee}
             challengeTitle={challengeTitle}
             collapsed={collapsed}
+            preQuestion={preQuestion}
             onViewExperience={() => setIsExperienceModalOpen(true)}
             // 한번 더 클릭하면 닫힘(토글)
             onViewExperienceSide={() => setIsSidePanelOpen((prev) => !prev)}

--- a/apps/mentor/src/pages/feedback/__tests__/MenteeInfo.test.tsx
+++ b/apps/mentor/src/pages/feedback/__tests__/MenteeInfo.test.tsx
@@ -82,3 +82,34 @@ describe('MenteeInfo 제출물 진입점', () => {
     expect(onViewExperience).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('MenteeInfo 사전 질문', () => {
+  const submitted = { ...base, id: 1, userId: 2, link: null };
+
+  it('preQuestion 전달 시 "사전 질문" 라벨과 내용을 노출한다', () => {
+    render(
+      <MenteeInfo mentee={submitted} preQuestion="자소서 3번 문항 봐주세요" />,
+    );
+
+    expect(screen.getByText('사전 질문')).toBeInTheDocument();
+    expect(screen.getByText('자소서 3번 문항 봐주세요')).toBeInTheDocument();
+  });
+
+  it('preQuestion 미전달 시 "사전 질문"을 노출하지 않는다', () => {
+    render(<MenteeInfo mentee={submitted} />);
+
+    expect(screen.queryByText('사전 질문')).toBeNull();
+  });
+
+  it('collapsed(컴팩트) 모드에서는 사전 질문을 노출하지 않는다', () => {
+    render(
+      <MenteeInfo
+        mentee={submitted}
+        collapsed
+        preQuestion="자소서 3번 문항 봐주세요"
+      />,
+    );
+
+    expect(screen.queryByText('사전 질문')).toBeNull();
+  });
+});

--- a/apps/mentor/src/pages/feedback/hooks/useFeedbackModal.ts
+++ b/apps/mentor/src/pages/feedback/hooks/useFeedbackModal.ts
@@ -17,6 +17,8 @@ interface UseFeedbackModalParams {
   onClose: () => void;
   challengeId: number;
   missionId: number;
+  /** 진입 시 초기 선택할 멘티의 출석 id (없으면 첫 멘티). */
+  initialAttendanceId?: number | null;
 }
 
 export function useFeedbackModal({
@@ -24,6 +26,7 @@ export function useFeedbackModal({
   onClose,
   challengeId,
   missionId,
+  initialAttendanceId,
 }: UseFeedbackModalParams) {
   const queryClient = useQueryClient();
 
@@ -47,7 +50,11 @@ export function useFeedbackModal({
     enabled: isOpen && !!challengeId && !!missionId,
   });
 
-  const attendanceList = attendanceData?.attendanceList ?? [];
+  // 초기 선택 effect가 배열 참조를 dep 으로 쓰므로 안정적인 참조로 메모.
+  const attendanceList = useMemo(
+    () => attendanceData?.attendanceList ?? [],
+    [attendanceData],
+  );
 
   // Current mentee from list
   const currentMentee = attendanceList[selectedIndex] ?? null;
@@ -60,12 +67,16 @@ export function useFeedbackModal({
     attendanceId: selectedAttendanceId ?? undefined,
   });
 
-  // Auto-select first mentee when modal opens
+  // 진입 시 초기 선택: 클릭한 멘티(initialAttendanceId)를 우선, 못 찾으면 첫 멘티.
   useEffect(() => {
     if (isOpen && attendanceList.length > 0 && selectedIndex === -1) {
-      setSelectedIndex(0);
+      const targetIndex =
+        initialAttendanceId != null
+          ? attendanceList.findIndex((a) => a.id === initialAttendanceId)
+          : -1;
+      setSelectedIndex(targetIndex >= 0 ? targetIndex : 0);
     }
-  }, [isOpen, attendanceList.length, selectedIndex]);
+  }, [isOpen, attendanceList, selectedIndex, initialAttendanceId]);
 
   // Sync editor content when selected mentee or feedbackData changes
   useEffect(() => {
@@ -142,6 +153,9 @@ export function useFeedbackModal({
     });
   }, [queryClient, challengeId, missionId, selectedAttendanceId]);
 
+  // 멘티 사전 질문 — 서면 상세 응답(attendanceDetailVo)에서 파생. BE 미배포 시 null.
+  const preQuestion = feedbackData?.attendanceDetailVo?.preQuestion ?? null;
+
   const isReadOnly =
     currentMentee?.feedbackStatus === 'COMPLETED' ||
     currentMentee?.feedbackStatus === 'CONFIRMED';
@@ -155,6 +169,7 @@ export function useFeedbackModal({
     editorContent,
     setEditorContent,
     currentMentee,
+    preQuestion,
     isReadOnly,
     isAbsent,
     attendanceList,

--- a/apps/mentor/src/pages/feedback/ui/MenteeInfo.tsx
+++ b/apps/mentor/src/pages/feedback/ui/MenteeInfo.tsx
@@ -26,6 +26,8 @@ interface MenteeInfoProps {
   mentee: MenteeData | null;
   challengeTitle?: string;
   collapsed?: boolean;
+  /** 멘티가 작성한 사전 질문 (서면 상세 응답에서 전달). 없으면 미표시. */
+  preQuestion?: string | null;
   /** 경험정리형 제출물(링크 없음·제출됨) 보기 진입 */
   onViewExperience?: () => void;
   /** 경험을 모달 왼쪽 패널에 띄워 보면서 피드백 작성 */
@@ -63,6 +65,7 @@ const MenteeInfo = ({
   mentee,
   challengeTitle,
   collapsed = false,
+  preQuestion,
   onViewExperience,
   onViewExperienceSide,
   onViewLinkSide,
@@ -274,6 +277,14 @@ const MenteeInfo = ({
                   희망 기업
                 </span>
                 <span>{mentee.wishCompany}</span>
+              </div>
+            ) : null}
+            {preQuestion ? (
+              <div className="flex gap-2">
+                <span className="w-16 shrink-0 text-neutral-400">
+                  사전 질문
+                </span>
+                <span className="whitespace-pre-wrap">{preQuestion}</span>
               </div>
             ) : null}
           </div>

--- a/apps/mentor/src/pages/feedback/ui/MobileFeedbackPage.tsx
+++ b/apps/mentor/src/pages/feedback/ui/MobileFeedbackPage.tsx
@@ -20,6 +20,7 @@ interface MobileFeedbackPageProps {
   missionId: number;
   challengeTitle?: string;
   missionTh?: number;
+  initialAttendanceId?: number | null;
 }
 
 const MobileFeedbackPage = ({
@@ -29,6 +30,7 @@ const MobileFeedbackPage = ({
   missionId,
   challengeTitle,
   missionTh,
+  initialAttendanceId,
 }: MobileFeedbackPageProps) => {
   const {
     selectedIndex,
@@ -36,6 +38,7 @@ const MobileFeedbackPage = ({
     editorContent,
     setEditorContent,
     currentMentee,
+    preQuestion,
     isReadOnly,
     isAbsent,
     attendanceList,
@@ -45,7 +48,13 @@ const MobileFeedbackPage = ({
     editorKey,
     confirmModal,
     handleConfirmResult,
-  } = useFeedbackModal({ isOpen, onClose, challengeId, missionId });
+  } = useFeedbackModal({
+    isOpen,
+    onClose,
+    challengeId,
+    missionId,
+    initialAttendanceId,
+  });
 
   const { hasPrevMentee, hasNextMentee, handlePrevMentee, handleNextMentee } =
     useMenteeNavigation({
@@ -242,7 +251,11 @@ const MobileFeedbackPage = ({
       </div>
 
       <div className="shrink-0 border-b border-gray-100 px-4 py-3">
-        <MenteeInfo mentee={currentMentee} challengeTitle={challengeTitle} />
+        <MenteeInfo
+          mentee={currentMentee}
+          challengeTitle={challengeTitle}
+          preQuestion={preQuestion}
+        />
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 py-3">


### PR DESCRIPTION
## 요약
멘토 "피드백 내역" 서면 피드백 관련 수정.

- **멘티 선택 버그**: 서면 멘티별 행 클릭 시 항상 첫 멘티 상세가 열리던 문제 수정. 클릭한 멘티의 `attendanceId`를 모달까지 관통시켜 본인 상세로 진입(못 찾으면 index 0 폴백 → 무회귀).
- **사전질문 노출**: 서면 상세 모달에 멘티 사전질문 렌더 배선(스키마 `nullish`·`MenteeInfo`).

## BE 선행 필요 (배포해도 무해, 미노출로 dormant)
- 사전질문 실제 표시: `GET /challenge/{id}/mission/{missionId}/feedback/attendances/{attendanceId}` VO에 `preQuestion` 추가
- 과거(종료) 챌린지 노출: `getMentorFeedbackManagement` Active→All (FE 변경 없음)

## 동작
- 멘티 선택: 즉시 동작
- 사전질문: BE 배포 후 활성 (스키마 nullish라 크래시 없음)

## 검증
- mentor `tsc` / 변경 파일 eslint 통과
- vitest 관련 테스트 통과(기존 실패 1건은 무관한 LIVE mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)