### PR TITLE
refactor: 라이브 피드백 모달 4:3+타이머 통일, LiveSessionTimer 패키지 공유화

### DIFF
--- a/apps/web/src/common/modal/JitsiEmbedModal.tsx
+++ b/apps/web/src/common/modal/JitsiEmbedModal.tsx
@@ -63,7 +63,7 @@ const JitsiEmbedModal = ({
               onExhausted={onExhausted}
               topLeftSlot={
                 startDate && endDate ? (
-                  <LiveSessionTimer startDate={startDate} endDate={endDate} />
+                  <LiveSessionTimer endDate={endDate} />
                 ) : undefined
               }
             />

--- a/apps/web/src/common/modal/JitsiEmbedModal.tsx
+++ b/apps/web/src/common/modal/JitsiEmbedModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { JitsiEmbed } from '@letscareer/ui/JitsiEmbed';
+import { JitsiEmbed, LiveSessionTimer } from '@letscareer/ui/JitsiEmbed';
 
 import BaseModal from '@/common/modal/BaseModal';
 
@@ -10,6 +10,8 @@ import BaseModal from '@/common/modal/BaseModal';
  * 방 URL 은 BE 가 합성한 `meetingUrl`(= jitsi base + 랜덤 `meetingRoom`)을 그대로 사용한다.
  * 멘토/멘티가 동일 `feedbackId` 의 동일 `meetingUrl` 을 받으므로 같은 방으로 수렴하며,
  * 방 이름이 서버 생성 랜덤값이라 외부에서 추측·접속할 수 없다.
+ *
+ * 멘토 앱·알림톡 링크 모달과 동일하게 4:3(웹캠 480p 기본 비율) 화면 + 좌상단 타이머.
  */
 interface JitsiEmbedModalProps {
   isOpen: boolean;
@@ -18,6 +20,10 @@ interface JitsiEmbedModalProps {
   meetingUrl: string | null;
   /** 모달 헤더 표시용 라벨 (선택). URL 에는 영향 없음. */
   spaceName?: string;
+  /** 세션 시작 ISO — 좌상단 타이머 표시용(선택). */
+  startDate?: string;
+  /** 세션 종료 ISO — 남은 시간 계산용(선택). */
+  endDate?: string;
   /** 우선순위 순 jitsi base 후보 — 현재 서버 실패 시 다음 후보로 failover. */
   baseCandidates?: ReadonlyArray<string | undefined>;
   /** 다음 base 를 BE 에 재등록하는 콜백 (`PATCH /feedback/{id}/meeting-url`). */
@@ -31,6 +37,8 @@ const JitsiEmbedModal = ({
   onClose,
   meetingUrl,
   spaceName,
+  startDate,
+  endDate,
   baseCandidates,
   registerBaseUrl,
   onExhausted,
@@ -39,24 +47,35 @@ const JitsiEmbedModal = ({
     <BaseModal
       isOpen={isOpen}
       onClose={onClose}
-      className="mx-2 h-[92vh] w-[1280px] max-w-full overflow-hidden rounded-2xl md:mx-4 md:h-[90vh] md:rounded-3xl"
+      className="rounded-xxl aspect-[4/3] h-[94vh] max-h-[980px] w-auto max-w-[96vw] overflow-hidden bg-neutral-900"
     >
-      {meetingUrl ? (
-        <JitsiEmbed
-          roomUrl={meetingUrl}
-          spaceName={spaceName}
-          onClose={onClose}
-          baseCandidates={baseCandidates}
-          registerBaseUrl={registerBaseUrl}
-          onExhausted={onExhausted}
-        />
-      ) : (
-        <div className="flex h-full items-center justify-center p-8 text-center text-sm text-neutral-500">
-          회의실이 아직 준비되지 않았습니다.
-          <br />
-          멘토가 라이브 피드백에 입장하면 회의실이 열립니다.
+      <div className="relative h-full w-full">
+        {/* 모달 자체가 4:3(웹캠 480p 기본 비율) → 화상이 박스를 꽉 채워 확대/크롭 없이 보인다.
+            로고+현재/남은 시간은 JitsiEmbed 좌상단 아크릴 패널(topLeftSlot)에 한 덩어리로 묶는다. */}
+        <div className="absolute inset-0">
+          {meetingUrl ? (
+            <JitsiEmbed
+              roomUrl={meetingUrl}
+              spaceName={spaceName}
+              onClose={onClose}
+              baseCandidates={baseCandidates}
+              registerBaseUrl={registerBaseUrl}
+              onExhausted={onExhausted}
+              topLeftSlot={
+                startDate && endDate ? (
+                  <LiveSessionTimer startDate={startDate} endDate={endDate} />
+                ) : undefined
+              }
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center p-8 text-center text-sm text-neutral-300">
+              회의실이 아직 준비되지 않았습니다.
+              <br />
+              멘토가 라이브 피드백에 입장하면 회의실이 열립니다.
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </BaseModal>
   );
 };

--- a/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
+++ b/apps/web/src/domain/challenge/feedback/live/section/ReservationInfoSection.tsx
@@ -163,6 +163,9 @@ const ReservationInfoSection = ({
           onClose={() => setIsJitsiOpen(false)}
           meetingUrl={meetingUrl ?? null}
           spaceName={mentor.nickname}
+          // 좌상단 타이머(현재 시각·남은 시간)용 세션 시간.
+          startDate={feedbackInfo?.startDate}
+          endDate={feedbackInfo?.endDate}
           // 입장 후 현재 서버가 죽어있으면(external_api.js 로드 실패) 다음 후보로 자동
           // 재등록(failover). BE 는 base + meetingRoom 을 덮어써 합성한다.
           baseCandidates={[

--- a/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
+++ b/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
@@ -2,14 +2,13 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { JitsiEmbed } from '@letscareer/ui/JitsiEmbed';
+import { JitsiEmbed, LiveSessionTimer } from '@letscareer/ui/JitsiEmbed';
 
 import BaseModal from '@/common/modal/BaseModal';
 import { isAllowedNotionUrl } from '@/common/lexical/utils/notion';
 import { twMerge } from '@/lib/twMerge';
 
 import type { LiveRole } from '../hooks/liveRole';
-import LiveSessionTimer from './LiveSessionTimer';
 import NotionSubmissionPanel from './NotionSubmissionPanel';
 
 /** 멘티 라이브 출석 상태 */

--- a/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
+++ b/apps/web/src/domain/live-feedback/ui/LiveFeedbackModal.tsx
@@ -291,7 +291,7 @@ const LiveFeedbackModal = ({
               onExhausted={onExhausted}
               topLeftSlot={
                 startDate && endDate ? (
-                  <LiveSessionTimer startDate={startDate} endDate={endDate} />
+                  <LiveSessionTimer endDate={endDate} />
                 ) : undefined
               }
             />

--- a/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
+++ b/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
@@ -21,8 +21,6 @@ function formatRemaining(remainingMs: number): string {
 }
 
 interface Props {
-  /** 세션 시작 ISO (현재 라벨엔 미사용 — 시작 전/후 분기 필요 시 확장). */
-  startDate?: string;
   /** 세션 종료 ISO — 남은 시간 계산용. */
   endDate?: string;
 }
@@ -33,7 +31,7 @@ interface Props {
  * 멘토 앱/알림톡/챌린지 피드백 입장 모달 공통. JitsiEmbed 좌상단 아크릴 패널(topLeftSlot)
  * 안에 들어가므로 자체 배경 없이 텍스트만 렌더한다. 1초마다 갱신(unmount 시 cleanup).
  */
-const LiveSessionTimer = ({ startDate, endDate }: Props) => {
+const LiveSessionTimer = ({ endDate }: Props) => {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   useEffect(() => {
@@ -44,7 +42,6 @@ const LiveSessionTimer = ({ startDate, endDate }: Props) => {
   const endMs = endDate ? new Date(endDate).getTime() : null;
   const remainingMs = endMs != null ? endMs - nowMs : null;
   const isEnded = remainingMs != null && remainingMs <= 0;
-  void startDate;
 
   return (
     <div className="pointer-events-none inline-flex items-center gap-3 px-1 text-white">

--- a/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
+++ b/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 const CLOCK_TICK_MS = 1000;

--- a/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
+++ b/packages/ui/src/JitsiEmbed/LiveSessionTimer.tsx
@@ -1,12 +1,16 @@
-'use client';
-
 import { useEffect, useState } from 'react';
-
-import dayjs from '@/lib/dayjs';
 
 const CLOCK_TICK_MS = 1000;
 const ONE_MINUTE_MS = 60 * 1000;
 const ONE_SECOND_MS = 1000;
+
+/** 현재 시각 "오전/오후 h:mm:ss" (ko) — 패키지엔 dayjs 가 없어 Intl 사용. */
+const clockFormatter = new Intl.DateTimeFormat('ko-KR', {
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: true,
+});
 
 /** 남은 시간 — 분:초(MM:SS)만 표시. */
 function formatRemaining(remainingMs: number): string {
@@ -17,17 +21,17 @@ function formatRemaining(remainingMs: number): string {
 }
 
 interface Props {
-  /** 세션 시작 ISO */
+  /** 세션 시작 ISO (현재 라벨엔 미사용 — 시작 전/후 분기 필요 시 확장). */
   startDate?: string;
-  /** 세션 종료 ISO */
+  /** 세션 종료 ISO — 남은 시간 계산용. */
   endDate?: string;
 }
 
 /**
  * 라이브 세션 타이머 — 현재 시각(오전/오후 12시간제) + 남은 시간(분:초).
  *
- * 멘토 앱과 동일 디자인. 좌상단 로고 아크릴 패널(JitsiEmbed topLeftSlot) 안에 들어가므로
- * 자체 배경 없이 텍스트만 렌더한다. 1초마다 갱신(unmount 시 cleanup).
+ * 멘토 앱/알림톡/챌린지 피드백 입장 모달 공통. JitsiEmbed 좌상단 아크릴 패널(topLeftSlot)
+ * 안에 들어가므로 자체 배경 없이 텍스트만 렌더한다. 1초마다 갱신(unmount 시 cleanup).
  */
 const LiveSessionTimer = ({ startDate, endDate }: Props) => {
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -40,14 +44,14 @@ const LiveSessionTimer = ({ startDate, endDate }: Props) => {
   const endMs = endDate ? new Date(endDate).getTime() : null;
   const remainingMs = endMs != null ? endMs - nowMs : null;
   const isEnded = remainingMs != null && remainingMs <= 0;
-  void startDate; // 시작 전/후 라벨이 필요해지면 사용.
+  void startDate;
 
   return (
     <div className="pointer-events-none inline-flex items-center gap-3 px-1 text-white">
       <span className="flex items-baseline gap-1.5">
         <span className="text-[11px] font-medium text-white/55">현재</span>
         <span className="text-[13px] font-semibold tabular-nums">
-          {dayjs(nowMs).format('A h:mm:ss')}
+          {clockFormatter.format(new Date(nowMs))}
         </span>
       </span>
       {remainingMs != null && (

--- a/packages/ui/src/JitsiEmbed/index.tsx
+++ b/packages/ui/src/JitsiEmbed/index.tsx
@@ -7,6 +7,8 @@ import { JitsiMeeting } from '@jitsi/react-sdk';
 import { LetsCareerLogo } from './LetsCareerLogo';
 import { useJitsiConnection } from './useJitsiConnection';
 
+export { default as LiveSessionTimer } from './LiveSessionTimer';
+
 interface JitsiEmbedProps {
   /** 회의실 URL — 외부에서 buildJitsiRoomUrl로 생성해 전달 (셀프호스팅 단일 사용) */
   roomUrl: string;


### PR DESCRIPTION
## 요약
- 멘티 챌린지 피드백 입장 모달(`common/modal/JitsiEmbedModal`)을 멘토·알림톡 모달과 동일한 **4:3 + 좌상단 타이머**로 통일.
- 중복되던 `LiveSessionTimer`를 `@letscareer/ui/JitsiEmbed`로 승격(공유화). web 소비처(common 모달·`LiveFeedbackModal`) 통합, 로컬 타이머 삭제.
- 패키지엔 dayjs가 없어 `Intl.DateTimeFormat` 사용.

## 동작
- 타이머는 `feedbackInfo.startDate/endDate`(기존 응답)로 즉시 동작. BE 무관.

## 검증
- web `tsc` / packages `tsc`(신규 타이머) / eslint 통과
- `JitsiEmbedModal.test.tsx` 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)