### PR TITLE
feat(admin): 라이브 피드백 예약관리·멘토스케줄 개편

### DIFF
--- a/apps/admin/src/api/feedback/feedback.ts
+++ b/apps/admin/src/api/feedback/feedback.ts
@@ -18,6 +18,7 @@ import {
   getAdminFeedbackHistoryResponseSchema,
   getAdminFeedbacksResponseSchema,
   getMentorFeedbackSlotsResponseSchema,
+  getMentorSlotCountsResponseSchema,
 } from './feedbackSchema';
 
 /**
@@ -157,6 +158,24 @@ export const useMentorFeedbackSlotsQuery = (
   return useQuery({
     ...mentorFeedbackSlotsQueryOptions(mentorId ?? 0, range),
     enabled: mentorId != null,
+  });
+};
+
+/**
+ * GET /admin/feedback/slot/count — 멘토별 오픈/예약 슬롯 건수 집계.
+ * 멘토 태그의 "오픈 N" 표시에 쓴다(멘토 1명씩 조회하던 N+1을 1콜로 대체).
+ * startDate 를 주면 그 시각 이후 슬롯만 집계한다(미래 오픈 슬롯).
+ */
+export const useAdminMentorSlotCountsQuery = (startDate?: string) => {
+  return useQuery({
+    queryKey: ['adminMentorSlotCounts', startDate],
+    queryFn: async () => {
+      const res = await axios.get('/admin/feedback/slot/count', {
+        params: startDate ? { startDate } : {},
+      });
+      return getMentorSlotCountsResponseSchema.parse(res.data.data)
+        .mentorSlotCountList;
+    },
   });
 };
 

--- a/apps/admin/src/api/feedback/feedbackSchema.ts
+++ b/apps/admin/src/api/feedback/feedbackSchema.ts
@@ -147,6 +147,17 @@ export type FeedbackSlotVo = z.infer<typeof feedbackSlotVoSchema>;
 export const getMentorFeedbackSlotsResponseSchema = z.object({
   feedbackSlotList: z.array(feedbackSlotVoSchema),
 });
+
+/** 멘토별 슬롯 오픈/예약 건수 집계 (GET /admin/feedback/slot/count) */
+export const mentorSlotCountVoSchema = z.object({
+  mentorId: z.number(),
+  openCount: z.number(),
+  reservedCount: z.number(),
+});
+export const getMentorSlotCountsResponseSchema = z.object({
+  mentorSlotCountList: z.array(mentorSlotCountVoSchema),
+});
+export type MentorSlotCountVo = z.infer<typeof mentorSlotCountVoSchema>;
 export type GetMentorFeedbackSlotsResponse = z.infer<
   typeof getMentorFeedbackSlotsResponseSchema
 >;

--- a/apps/admin/src/api/feedback/feedbackSchema.ts
+++ b/apps/admin/src/api/feedback/feedbackSchema.ts
@@ -43,8 +43,10 @@ export const feedbackAdminVoSchema = z.object({
   mentorStatus: feedbackAttendanceStatusSchema,
   menteeStatus: feedbackAttendanceStatusSchema,
   status: feedbackStatusSchema,
-  /** 피드백 회차(몇 회차). BE feedback.th. */
+  /** 라이브 피드백 순번(BE feedback.th) — 실제 미션 회차가 아님. 표시는 missionTh 사용. */
   th: z.number().nullable().optional(),
+  /** 실제 미션 회차(BE mission.th). 캘린더/리스트의 "N회차"는 이 값을 쓴다. */
+  missionTh: z.number().nullable().optional(),
   /**
    * 예약을 다른 날로 옮긴 횟수.
    * BE 미제공(예약 변경 내역 자체가 LC-3065 미구현) → 목 전용. 실 API 에 없으면 undefined → 0 으로 본다.

--- a/apps/admin/src/api/feedback/feedbackSchema.ts
+++ b/apps/admin/src/api/feedback/feedbackSchema.ts
@@ -43,6 +43,8 @@ export const feedbackAdminVoSchema = z.object({
   mentorStatus: feedbackAttendanceStatusSchema,
   menteeStatus: feedbackAttendanceStatusSchema,
   status: feedbackStatusSchema,
+  /** 피드백 회차(몇 회차). BE feedback.th. */
+  th: z.number().nullable().optional(),
   /**
    * 예약을 다른 날로 옮긴 횟수.
    * BE 미제공(예약 변경 내역 자체가 LC-3065 미구현) → 목 전용. 실 API 에 없으면 undefined → 0 으로 본다.

--- a/apps/admin/src/pages/challenge/feedback-operation/FeedbackOperationPage.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/FeedbackOperationPage.tsx
@@ -1,4 +1,5 @@
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, lazy } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { twMerge } from '@/lib/twMerge';
 import MentorNoticeManagement from './MentorNoticeManagement';
 import OngoingChallenges from './OngoingChallenges';
@@ -14,8 +15,22 @@ const tabs: { id: Tab; label: string }[] = [
   { id: 'live', label: 'LIVE 피드백' },
 ];
 
+function isTab(value: string | null): value is Tab {
+  return value === 'notice' || value === 'ongoing' || value === 'live';
+}
+
 export default function FeedbackOperationPage() {
-  const [activeTab, setActiveTab] = useState<Tab>('notice');
+  // 탭 상태를 URL(?tab=)에 둔다. 새로고침해도 보던 탭이 유지되어
+  // 공지 탭으로 리셋되며 불필요한 재조회가 나가는 문제를 막는다.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const activeTab: Tab = isTab(tabParam) ? tabParam : 'notice';
+
+  const setActiveTab = (tab: Tab) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', tab);
+    setSearchParams(next, { replace: true });
+  };
 
   return (
     <section className="p-5">

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/LiveFeedbackTab.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/LiveFeedbackTab.tsx
@@ -34,15 +34,9 @@ export default function LiveFeedbackTab() {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="text-medium20 text-neutral-0 font-semibold">
-          전체 예약 목록
-        </h2>
-        <div className="border-neutral-90 bg-neutral-95 text-xxsmall12 text-neutral-40 rounded-md border px-3 py-1.5">
-          참고 · 미션 회차 표시 버그 수정 중이에요. 추가 요청은 임성빈에게
-          문의해 주세요.
-        </div>
-      </div>
+      <h2 className="text-medium20 text-neutral-0 font-semibold">
+        전체 예약 목록
+      </h2>
 
       <nav className="border-neutral-80 flex gap-1 border-b">
         {subTabs.map((tab) => (

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/LiveFeedbackTab.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/LiveFeedbackTab.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { twMerge } from '@/lib/twMerge';
 import ReservationManagement from './reservation/ReservationManagement';
 
@@ -14,14 +15,34 @@ const subTabs: { id: SubTab; label: string }[] = [
   { id: 'schedule', label: '멘토 스케줄' },
 ];
 
+function isSubTab(value: string | null): value is SubTab {
+  return value === 'reservation' || value === 'schedule';
+}
+
 export default function LiveFeedbackTab() {
-  const [subTab, setSubTab] = useState<SubTab>('reservation');
+  // 하위 탭 상태도 URL(?sub=)에 둔다. 새로고침 시 예약 관리로 리셋되며
+  // 그 조회가 다시 나가는 것을 막는다.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const subParam = searchParams.get('sub');
+  const subTab: SubTab = isSubTab(subParam) ? subParam : 'reservation';
+
+  const setSubTab = (id: SubTab) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('sub', id);
+    setSearchParams(next, { replace: true });
+  };
 
   return (
     <div className="flex flex-col gap-6">
-      <h2 className="text-medium20 text-neutral-0 font-semibold">
-        전체 예약 목록
-      </h2>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-medium20 text-neutral-0 font-semibold">
+          전체 예약 목록
+        </h2>
+        <div className="border-neutral-90 bg-neutral-95 text-xxsmall12 text-neutral-40 rounded-md border px-3 py-1.5">
+          참고 · 미션 회차 표시 버그 수정 중이에요. 추가 요청은 임성빈에게
+          문의해 주세요.
+        </div>
+      </div>
 
       <nav className="border-neutral-80 flex gap-1 border-b">
         {subTabs.map((tab) => (

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/MentorScheduleView.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/MentorScheduleView.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react';
 import {
   useAdminFeedbackListQuery,
+  useAdminMentorSlotCountsQuery,
   useMentorFeedbackSlotsQuery,
 } from '@/api/feedback/feedback';
 import type { FeedbackAdminVo } from '@/api/feedback/feedbackSchema';
 import { useAdminUserMentorListQuery } from '@/api/mentor/mentor';
+import dayjs from '@/lib/dayjs';
 import { twMerge } from '@/lib/twMerge';
 import { getMentorColor } from '../constants/colors';
 import { buildReservationBlocks } from '../reservation/ui/ReservationCalendarView';
@@ -71,6 +73,15 @@ export default function MentorScheduleView() {
     });
     return map;
   }, [reservations]);
+
+  // 멘토별 오픈 슬롯 건수(현재 이후). BE 집계 API 1콜로 태그에 표시.
+  const nowIso = useMemo(() => dayjs().format('YYYY-MM-DDTHH:mm:ss'), []);
+  const { data: slotCounts } = useAdminMentorSlotCountsQuery(nowIso);
+  const openCountByMentor = useMemo(() => {
+    const map = new Map<number, number>();
+    (slotCounts ?? []).forEach((s) => map.set(s.mentorId, s.openCount));
+    return map;
+  }, [slotCounts]);
 
   const filteredMentors = useMemo(() => {
     const kw = keyword.trim();
@@ -183,6 +194,8 @@ export default function MentorScheduleView() {
                   {mentor.name}
                   <span className="ml-1 opacity-60">
                     · 예정 {upcomingCountByMentor.get(mentor.id) ?? 0}
+                    {slotCounts != null &&
+                      ` · 오픈 ${openCountByMentor.get(mentor.id) ?? 0}`}
                   </span>
                 </button>
               );

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/MentorScheduleView.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/MentorScheduleView.tsx
@@ -1,8 +1,22 @@
 import { useMemo, useState } from 'react';
-import { useQueries } from '@tanstack/react-query';
-import { mentorFeedbackSlotsQueryOptions } from '@/api/feedback/feedback';
-import { useUserAdminQuery } from '@/api/user/user';
+import {
+  useAdminFeedbackListQuery,
+  useMentorFeedbackSlotsQuery,
+} from '@/api/feedback/feedback';
+import type { FeedbackAdminVo } from '@/api/feedback/feedbackSchema';
+import { useAdminUserMentorListQuery } from '@/api/mentor/mentor';
+import { twMerge } from '@/lib/twMerge';
 import { getMentorColor } from '../constants/colors';
+import { buildReservationBlocks } from '../reservation/ui/ReservationCalendarView';
+import ReservationDetailModal from '../reservation/ui/ReservationDetailModal';
+import ReservationListView from '../reservation/ui/ReservationListView';
+import ReservationRescheduleModal from '../reservation/ui/ReservationRescheduleModal';
+import ViewToggle, { type ReservationView } from '../reservation/ui/ViewToggle';
+import {
+  sortReservations,
+  type SortKey,
+  type SortState,
+} from '../reservation/utils/sortReservations';
 import WeeklyGrid from '../weekly-calendar/WeeklyGrid';
 import WeekNavigator from '../weekly-calendar/WeekNavigator';
 import {
@@ -10,93 +24,249 @@ import {
   getWeekRange,
   shiftWeek,
 } from '../weekly-calendar/weekUtils';
-import { buildSlotBlocks, type MentorSlots } from './buildSlotBlocks';
-
-const MENTOR_PAGE_SIZE = 1000;
+import { buildSlotBlocks } from './buildSlotBlocks';
 
 /**
- * 모든 멘토의 주간 슬롯을 시간대 그리드에 표시한다.
+ * 멘토 스케줄 — 멘토를 태그로 나열하고, 선택한 1명의 스케줄을 캘린더/리스트로 본다.
  *
- * 멘토 일괄 스케줄 API 가 없어(PRD §3 BE 갭) 멘토 목록 조회 후
- * 멘토마다 slot/{mentorId} 를 useQueries 로 병렬 호출해 합산한다(N+1 허용).
+ * - 멘토 목록은 전용 API(/admin/user/mentor, 서버 isMentor 필터)를 쓴다.
+ * - 캘린더: 오픈 슬롯(가용 시간) + 예약(전체 정보, 클릭 시 상세). 예약탭 캘린더와 같은 정보.
+ * - 리스트: 선택 멘토의 예약을 표로. 상세·예약변경은 예약탭과 동일 흐름.
+ * - 태그의 "예정 N" 은 앞으로 진행할(시작이 현재 이후) 예약 건수.
  */
 export default function MentorScheduleView() {
   const [weekStart, setWeekStart] = useState(() => getMonday(new Date()));
-
-  const { data: mentorData } = useUserAdminQuery({
-    isMentor: true,
-    pageable: { page: 1, size: MENTOR_PAGE_SIZE },
+  const [selectedMentorId, setSelectedMentorId] = useState<number | null>(null);
+  const [keyword, setKeyword] = useState('');
+  const [view, setView] = useState<ReservationView>('calendar');
+  const [sort, setSort] = useState<SortState>({
+    key: 'dateTime',
+    direction: 'desc',
   });
+  const [selectedFeedbackId, setSelectedFeedbackId] = useState<number | null>(
+    null,
+  );
+  const [rescheduleTarget, setRescheduleTarget] =
+    useState<FeedbackAdminVo | null>(null);
 
+  const { data: mentorData } = useAdminUserMentorListQuery();
   const mentors = useMemo(
     () =>
-      (mentorData?.userAdminList ?? []).map((u) => ({
-        id: u.userInfo.id,
-        name: u.userInfo.name,
-      })),
+      (mentorData?.mentorList ?? []).map((m) => ({ id: m.id, name: m.name })),
     [mentorData],
+  );
+
+  // 예약 목록(1콜, 예약탭과 캐시 공유). 태그 예정 건수 + 선택 멘토의 예약에 쓴다.
+  const { data: reservations, isLoading: reservationsLoading } =
+    useAdminFeedbackListQuery();
+
+  // 앞으로 할(예정) 예약 건수 = 시작이 현재 이후인 예약.
+  const upcomingCountByMentor = useMemo(() => {
+    const nowMs = Date.now();
+    const map = new Map<number, number>();
+    (reservations ?? []).forEach((r) => {
+      if (new Date(r.startDate).getTime() >= nowMs) {
+        map.set(r.mentorId, (map.get(r.mentorId) ?? 0) + 1);
+      }
+    });
+    return map;
+  }, [reservations]);
+
+  const filteredMentors = useMemo(() => {
+    const kw = keyword.trim();
+    const list = kw ? mentors.filter((m) => m.name.includes(kw)) : mentors;
+    // 예정 예약 많은 순(동수면 이름순).
+    return [...list].sort((a, b) => {
+      const diff =
+        (upcomingCountByMentor.get(b.id) ?? 0) -
+        (upcomingCountByMentor.get(a.id) ?? 0);
+      return diff !== 0 ? diff : a.name.localeCompare(b.name);
+    });
+  }, [mentors, keyword, upcomingCountByMentor]);
+
+  const selectedMentor = useMemo(
+    () => mentors.find((m) => m.id === selectedMentorId) ?? null,
+    [mentors, selectedMentorId],
+  );
+
+  // 선택 멘토의 예약(전체 기간). 리스트뷰·캘린더 예약 블록에 쓴다.
+  const mentorReservations = useMemo(
+    () => (reservations ?? []).filter((r) => r.mentorId === selectedMentorId),
+    [reservations, selectedMentorId],
+  );
+
+  const sortedMentorReservations = useMemo(
+    () => sortReservations(mentorReservations, sort),
+    [mentorReservations, sort],
   );
 
   const range = useMemo(() => getWeekRange(weekStart), [weekStart]);
 
-  // 멘토별 슬롯 병렬 조회.
-  const slotQueries = useQueries({
-    queries: mentors.map((mentor) =>
-      mentorFeedbackSlotsQueryOptions(mentor.id, {
-        startDate: range.startDate,
-        endDate: range.endDate,
-      }),
-    ),
-  });
-
-  const blocks = useMemo(() => {
-    const mentorSlots: MentorSlots[] = mentors.map((mentor, i) => ({
-      mentorId: mentor.id,
-      mentorName: mentor.name,
-      slots: slotQueries[i]?.data ?? [],
-    }));
-    return buildSlotBlocks(mentorSlots, weekStart);
-  }, [mentors, slotQueries, weekStart]);
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <WeekNavigator
-          weekStart={weekStart}
-          onPrev={() => setWeekStart((w) => shiftWeek(w, -1))}
-          onNext={() => setWeekStart((w) => shiftWeek(w, 1))}
-          onToday={() => setWeekStart(getMonday(new Date()))}
-        />
-        <MentorLegend mentorNames={mentors.map((m) => m.name)} />
-      </div>
-      <WeeklyGrid weekStart={weekStart} blocks={blocks} />
-    </div>
+  // 오픈 슬롯(가용 시간)만 조회 → 캘린더에 "오픈" 블록으로 표시.
+  const { data: openSlots } = useMentorFeedbackSlotsQuery(
+    selectedMentorId ?? undefined,
+    {
+      startDate: range.startDate,
+      endDate: range.endDate,
+      statusList: ['OPEN'],
+    },
   );
-}
 
-/** 멘토별 색상 범례 + OPEN/RESERVED 표기 안내. */
-function MentorLegend({ mentorNames }: { mentorNames: string[] }) {
-  // 색상은 이름 기반이라 동명이인은 같은 색 → 고유 이름만 한 번씩 표기.
-  const uniqueNames = [...new Set(mentorNames)];
+  // 캘린더 블록 = 오픈 슬롯 + 예약(전체 정보, 클릭 시 상세).
+  const blocks = useMemo(() => {
+    if (!selectedMentor) return [];
+    const openBlocks = buildSlotBlocks(
+      [
+        {
+          mentorId: selectedMentor.id,
+          mentorName: selectedMentor.name,
+          slots: openSlots ?? [],
+        },
+      ],
+      weekStart,
+    );
+    const reservedBlocks = buildReservationBlocks(
+      mentorReservations,
+      weekStart,
+      setSelectedFeedbackId,
+    );
+    return [...openBlocks, ...reservedBlocks];
+  }, [selectedMentor, openSlots, mentorReservations, weekStart]);
+
+  const toggleSort = (key: SortKey) =>
+    setSort((prev) =>
+      prev.key === key
+        ? { key, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
+        : { key, direction: 'asc' },
+    );
+
+  const mentorColor = selectedMentor
+    ? getMentorColor(selectedMentor.name)
+    : null;
+
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-      {uniqueNames.map((name) => {
-        const color = getMentorColor(name);
-        return (
-          <span
-            key={name}
-            className="text-xxsmall12 text-neutral-0 inline-flex items-center gap-1"
-          >
-            <span
-              className={`inline-block h-3 w-3 rounded-sm border ${color.bg} ${color.border}`}
+    <div className="flex flex-col gap-4">
+      {/* 멘토 태그 목록 — 클릭 시 해당 멘토 스케줄 조회 */}
+      <div className="flex flex-col gap-2">
+        <input
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="멘토 이름 검색"
+          className="border-neutral-80 text-xsmall14 w-full max-w-xs rounded-md border px-3 py-2"
+        />
+        <div className="border-neutral-90 flex max-h-52 flex-wrap gap-2 overflow-y-auto rounded-md border p-2.5">
+          {filteredMentors.length === 0 ? (
+            <span className="text-xsmall14 text-neutral-40">
+              표시할 멘토가 없습니다.
+            </span>
+          ) : (
+            filteredMentors.map((mentor) => {
+              const selected = mentor.id === selectedMentorId;
+              const color = getMentorColor(mentor.name);
+              return (
+                <button
+                  key={mentor.id}
+                  type="button"
+                  onClick={() => setSelectedMentorId(mentor.id)}
+                  className={twMerge(
+                    'text-xsmall14 rounded-full border px-4 py-2 font-medium',
+                    selected
+                      ? twMerge(
+                          color.bg,
+                          color.border,
+                          color.text,
+                          'font-semibold',
+                        )
+                      : 'border-neutral-80 text-neutral-40 bg-white',
+                  )}
+                >
+                  {mentor.name}
+                  <span className="ml-1 opacity-60">
+                    · 예정 {upcomingCountByMentor.get(mentor.id) ?? 0}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+
+      {/* 선택된 멘토 영역 */}
+      {selectedMentor ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <ViewToggle value={view} onChange={setView} />
+            <span className="text-xsmall14 text-neutral-0 font-semibold">
+              {selectedMentor.name} 스케줄
+            </span>
+          </div>
+
+          {view === 'calendar' ? (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <WeekNavigator
+                  weekStart={weekStart}
+                  onPrev={() => setWeekStart((w) => shiftWeek(w, -1))}
+                  onNext={() => setWeekStart((w) => shiftWeek(w, 1))}
+                  onToday={() => setWeekStart(getMonday(new Date()))}
+                />
+                <div className="flex items-center gap-3">
+                  <span className="text-xxsmall12 text-neutral-40 flex items-center gap-1.5">
+                    <span
+                      className={twMerge(
+                        'h-3 w-3 rounded-sm border',
+                        mentorColor?.bg,
+                        mentorColor?.border,
+                      )}
+                    />
+                    예약
+                  </span>
+                  <span className="text-xxsmall12 text-neutral-40 flex items-center gap-1.5">
+                    <span className="border-neutral-80 bg-neutral-95 h-3 w-3 rounded-sm border" />
+                    오픈
+                  </span>
+                </div>
+              </div>
+              <WeeklyGrid weekStart={weekStart} blocks={blocks} />
+            </div>
+          ) : (
+            <ReservationListView
+              reservations={sortedMentorReservations}
+              sort={sort}
+              onToggleSort={toggleSort}
+              onView={setSelectedFeedbackId}
+              onReschedule={setRescheduleTarget}
+              isLoading={reservationsLoading}
+              emptyMessage="이 멘토의 예약 내역이 없습니다."
             />
-            {name}
-          </span>
-        );
-      })}
-      <span className="text-xxsmall12 text-neutral-40 ml-2">
-        (채움=예약, 점선=오픈)
-      </span>
+          )}
+        </div>
+      ) : (
+        <div className="text-xsmall14 text-neutral-40 py-16 text-center">
+          멘토를 선택하면 해당 멘토의 스케줄이 표시됩니다.
+        </div>
+      )}
+
+      {/* 예약 상세 → 예약 변경 전환 (예약탭과 동일 흐름) */}
+      <ReservationDetailModal
+        feedbackId={selectedFeedbackId}
+        onClose={() => setSelectedFeedbackId(null)}
+        onReschedule={() => {
+          const target = mentorReservations.find(
+            (r) => r.feedbackId === selectedFeedbackId,
+          );
+          if (target) {
+            setSelectedFeedbackId(null);
+            setRescheduleTarget(target);
+          }
+        }}
+      />
+      {rescheduleTarget && (
+        <ReservationRescheduleModal
+          feedback={rescheduleTarget}
+          onClose={() => setRescheduleTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/buildSlotBlocks.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/mentor-schedule/buildSlotBlocks.tsx
@@ -1,6 +1,4 @@
 import type { FeedbackSlotVo } from '@/api/feedback/feedbackSchema';
-import { twMerge } from '@/lib/twMerge';
-import { getMentorColor } from '../constants/colors';
 import type { GridBlock } from '../weekly-calendar/WeeklyGrid';
 import { getSlotPosition } from '../weekly-calendar/weekUtils';
 
@@ -17,40 +15,44 @@ const SLOT_STATUS_LABEL: Record<FeedbackSlotVo['status'], string> = {
 };
 
 /**
- * 멘토별 슬롯을 주간 그리드 블록으로 합산·변환한다.
- *
- * - 색상 hue 는 멘토명 기준(getMentorColor).
- * - 상태 구분: RESERVED 는 채움(진한 배경), OPEN 은 점선 테두리 + 옅은 표시.
+ * 슬롯 상태별 스타일. 예약과 오픈을 색으로 확실히 구분한다.
+ * (이전 점선/흰배경은 흰 그리드에서 잘 안 보여 색 채움으로 교체)
+ */
+const SLOT_STATUS_CLASS: Record<FeedbackSlotVo['status'], string> = {
+  // 예약: 채운 인디고 블록(강조)
+  RESERVED: 'border-indigo-600 bg-indigo-500 text-white shadow-sm',
+  // 오픈: 가용 시간 표시. 강조하지 않도록 아주 연한 회색.
+  OPEN: 'border-neutral-80 bg-neutral-95 text-neutral-40',
+};
+
+/**
+ * 선택된 멘토의 슬롯을 주간 그리드 블록으로 변환한다.
+ * 상태(예약/오픈)를 색으로 구분한다.
  */
 export function buildSlotBlocks(
   mentorSlots: MentorSlots[],
   weekStart: string,
 ): GridBlock[] {
-  return mentorSlots.flatMap(({ mentorId, mentorName, slots }) => {
-    const color = getMentorColor(mentorName);
-    return slots.map((slot) => {
+  return mentorSlots.flatMap(({ mentorId, slots }) =>
+    slots.map((slot) => {
       const { dayIndex, slotIndex, slotSpan } = getSlotPosition(
         slot.startDate,
         slot.endDate,
         weekStart,
       );
-      const statusClass =
-        slot.status === 'RESERVED'
-          ? twMerge(color.bg, color.border, color.text)
-          : twMerge('border-dashed bg-white', color.border, color.text);
       return {
         key: `${mentorId}-${slot.feedbackSlotId}`,
         dayIndex,
         slotIndex,
         slotSpan,
-        className: statusClass,
+        className: SLOT_STATUS_CLASS[slot.status],
+        title: SLOT_STATUS_LABEL[slot.status],
         content: (
-          <>
-            <div className="truncate font-semibold">{mentorName}</div>
-            <div className="truncate">{SLOT_STATUS_LABEL[slot.status]}</div>
-          </>
+          <span className="truncate text-center font-semibold">
+            {SLOT_STATUS_LABEL[slot.status]}
+          </span>
         ),
       };
-    });
-  });
+    }),
+  );
 }

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ReservationManagement.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ReservationManagement.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
-import { useUserAdminQuery } from '@/api/user/user';
+import { useAdminUserMentorListQuery } from '@/api/mentor/mentor';
 import { useAdminFeedbackListQuery } from '@/api/feedback/feedback';
 import type { FeedbackAdminVo } from '@/api/feedback/feedbackSchema';
 import axios from '@/utils/axios';
@@ -71,11 +71,10 @@ export default function ReservationManagement() {
     useState<FeedbackAdminVo | null>(null);
 
   // 필터 드롭다운 옵션 소스. 예약 목록과 독립적이라 병렬로 패칭된다.
+  // 멘토는 전용 API(/admin/user/mentor, 서버 isMentor 필터)를 쓴다.
+  // /admin/user 는 isMentor 파라미터를 무시해 전체 유저가 오는 버그가 있었다.
   const { data: challengeData } = useChallengeDropdownQuery();
-  const { data: mentorData } = useUserAdminQuery({
-    isMentor: true,
-    pageable: { page: 1, size: DROPDOWN_PAGE_SIZE },
-  });
+  const { data: mentorData } = useAdminUserMentorListQuery();
 
   const listParams = useMemo(() => buildListParams(filter), [filter]);
   const { data: reservations, isLoading } =
@@ -92,9 +91,9 @@ export default function ReservationManagement() {
 
   const mentorOptions = useMemo(
     () =>
-      (mentorData?.userAdminList ?? []).map((u) => ({
-        value: String(u.userInfo.id),
-        label: u.userInfo.name,
+      (mentorData?.mentorList ?? []).map((m) => ({
+        value: String(m.id),
+        label: m.name,
       })),
     [mentorData],
   );
@@ -121,7 +120,7 @@ export default function ReservationManagement() {
         mentorOptions={mentorOptions}
       />
 
-      <div className="flex justify-end">
+      <div className="flex justify-start">
         <ViewToggle value={view} onChange={setView} />
       </div>
 
@@ -136,7 +135,10 @@ export default function ReservationManagement() {
         />
       ) : (
         <Suspense fallback={null}>
-          <ReservationCalendarView reservations={visibleReservations} />
+          <ReservationCalendarView
+            reservations={visibleReservations}
+            onView={setSelectedFeedbackId}
+          />
         </Suspense>
       )}
 
@@ -144,6 +146,15 @@ export default function ReservationManagement() {
         <ReservationDetailModal
           feedbackId={selectedFeedbackId}
           onClose={() => setSelectedFeedbackId(null)}
+          onReschedule={() => {
+            const target = (reservations ?? []).find(
+              (r) => r.feedbackId === selectedFeedbackId,
+            );
+            if (target) {
+              setSelectedFeedbackId(null);
+              setRescheduleTarget(target);
+            }
+          }}
         />
       </Suspense>
 

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationCalendarView.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationCalendarView.tsx
@@ -12,12 +12,15 @@ import {
 
 interface ReservationCalendarViewProps {
   reservations: FeedbackAdminVo[];
+  /** 블록 클릭 시 상세 열기. 리스트 뷰의 "상세"와 동일 동작. */
+  onView?: (feedbackId: number) => void;
 }
 
 /** 예약(FeedbackAdminVo)을 주간 시간대 그리드 블록으로 변환한다. */
 export function buildReservationBlocks(
   reservations: FeedbackAdminVo[],
   weekStart: string,
+  onView?: (feedbackId: number) => void,
 ): GridBlock[] {
   return reservations.map((r) => {
     const { dayIndex, slotIndex, slotSpan } = getSlotPosition(
@@ -26,16 +29,23 @@ export function buildReservationBlocks(
       weekStart,
     );
     const color = getMentorColor(r.mentorName);
+    const roundLabel = r.th != null ? `${r.th}회차 · ` : '';
+    const subLine = `${roundLabel}${r.mentorName} · ${r.menteeName}`;
     return {
       key: String(r.feedbackId),
       dayIndex,
       slotIndex,
       slotSpan,
       className: twMerge(color.bg, color.border, color.text),
+      onClick: onView ? () => onView(r.feedbackId) : undefined,
+      title: `${r.programTitle || '-'} · ${subLine}`,
+      isSession: true,
       content: (
         <>
-          <div className="truncate font-semibold">{r.menteeName}</div>
-          <div className="truncate">{r.programTitle || '-'}</div>
+          <span className="truncate font-semibold">
+            {r.programTitle || '-'}
+          </span>
+          <span className="truncate opacity-80">{subLine}</span>
         </>
       ),
     };
@@ -45,12 +55,13 @@ export function buildReservationBlocks(
 /** 예약 관리 캘린더 뷰. 표시 주의 예약만 그리드에 배치한다. */
 export default function ReservationCalendarView({
   reservations,
+  onView,
 }: ReservationCalendarViewProps) {
   const [weekStart, setWeekStart] = useState(() => getMonday(new Date()));
 
   const blocks = useMemo(
-    () => buildReservationBlocks(reservations, weekStart),
-    [reservations, weekStart],
+    () => buildReservationBlocks(reservations, weekStart, onView),
+    [reservations, weekStart, onView],
   );
 
   return (

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationCalendarView.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationCalendarView.tsx
@@ -29,7 +29,7 @@ export function buildReservationBlocks(
       weekStart,
     );
     const color = getMentorColor(r.mentorName);
-    const roundLabel = r.th != null ? `${r.th}회차 · ` : '';
+    const roundLabel = r.missionTh != null ? `${r.missionTh}회차 · ` : '';
     const subLine = `${roundLabel}${r.mentorName} · ${r.menteeName}`;
     return {
       key: String(r.feedbackId),

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationDetailModal.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ReservationDetailModal.tsx
@@ -29,6 +29,8 @@ interface ReservationDetailModalProps {
   /** 선택된 예약 id. null 이면 모달을 렌더하지 않는다(닫힘). */
   feedbackId: number | null;
   onClose: () => void;
+  /** 지정 시 헤더에 "예약 변경" 버튼을 노출하고, 클릭하면 예약 변경 모달로 전환한다. */
+  onReschedule?: () => void;
 }
 
 const ATTENDANCE_LABEL: Record<FeedbackAttendanceStatus, string> = {
@@ -341,6 +343,7 @@ function EditPanel({ detail }: { detail: FeedbackDetailAdminVo }) {
 export default function ReservationDetailModal({
   feedbackId,
   onClose,
+  onReschedule,
 }: ReservationDetailModalProps) {
   const {
     data: detail,
@@ -372,14 +375,25 @@ export default function ReservationDetailModal({
           <h3 className="text-medium16 text-neutral-0 font-semibold">
             예약 상세
           </h3>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="닫기"
-            className="text-neutral-40 hover:text-neutral-0 text-lg"
-          >
-            ✕
-          </button>
+          <div className="flex items-center gap-2">
+            {onReschedule && (
+              <button
+                type="button"
+                onClick={onReschedule}
+                className="border-primary text-xsmall14 text-primary hover:bg-primary/5 rounded-md border px-3 py-1.5 font-semibold transition-colors"
+              >
+                예약 변경
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="닫기"
+              className="text-neutral-40 hover:text-neutral-0 text-lg"
+            >
+              ✕
+            </button>
+          </div>
         </div>
 
         <div className="overflow-y-auto px-6 py-5">

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ViewToggle.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/reservation/ui/ViewToggle.tsx
@@ -14,17 +14,17 @@ interface ViewToggleProps {
 
 export default function ViewToggle({ value, onChange }: ViewToggleProps) {
   return (
-    <div className="border-neutral-80 inline-flex rounded-md border p-0.5">
+    <div className="bg-neutral-95 inline-flex gap-0.5 rounded-full p-1">
       {views.map((view) => (
         <button
           type="button"
           key={view.id}
           onClick={() => onChange(view.id)}
           className={twMerge(
-            'text-xsmall14 rounded px-3 py-1.5',
+            'text-xsmall14 rounded-full px-4 py-1.5 font-medium transition',
             value === view.id
-              ? 'bg-neutral-0 text-white'
-              : 'text-neutral-40 bg-transparent',
+              ? 'text-neutral-0 bg-white shadow-sm'
+              : 'text-neutral-40 hover:text-neutral-0',
           )}
         >
           {view.label}

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/weekly-calendar/WeeklyGrid.tsx
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/weekly-calendar/WeeklyGrid.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
 import { twMerge } from '@/lib/twMerge';
 import {
   formatDayHeader,
+  formatNowLabel,
+  getNowIndicator,
   getTimeLabels,
   getWeekDays,
   SLOTS_PER_DAY,
@@ -19,6 +22,77 @@ export interface GridBlock {
   className: string;
   /** 블록 내부 표시 내용 */
   content: React.ReactNode;
+  /** 클릭 시 동작(옵션). 지정되면 블록이 클릭 가능해진다. */
+  onClick?: () => void;
+  /** 마우스 오버 툴팁(옵션). 잘린 텍스트 전체를 보여줄 때 쓴다. */
+  title?: string;
+  /** 실제 진행(예약) 블록인지. 그 시간대 "진행 박스"·건수 표시에 쓴다. */
+  isSession?: boolean;
+}
+
+interface LaidBlock extends GridBlock {
+  /** 같은 시간대 겹침 시 세로 레인 인덱스(0=맨 위). */
+  laneIndex: number;
+}
+
+/** 겹치는 블록들을 하나로 묶은 그룹(같은 시간대 = 하나의 "진행" 묶음). */
+interface DayCluster {
+  /** 묶음 시작 슬롯 */
+  startSlot: number;
+  /** 묶음 끝 슬롯(exclusive) */
+  endSlot: number;
+  /** 세로로 쌓인 레인 수(= 동시 진행 최대 개수) */
+  laneCount: number;
+  /** 예약(진행) 블록을 포함하는지 → 진행 박스 대상 */
+  hasSession: boolean;
+  blocks: LaidBlock[];
+}
+
+/**
+ * 한 요일의 블록들을 겹침(같은 시간대) 기준으로 묶고, 각 블록에 세로 레인을 부여한다.
+ * 겹치는 블록끼리 한 클러스터(= 한 시간대 진행 묶음)로 만든다.
+ */
+function layoutDayClusters(dayBlocks: GridBlock[]): DayCluster[] {
+  const sorted = [...dayBlocks].sort(
+    (a, b) => a.slotIndex - b.slotIndex || a.slotSpan - b.slotSpan,
+  );
+  const clusters: DayCluster[] = [];
+  let cur: LaidBlock[] = [];
+  let curStart = -1;
+  let curEnd = -1;
+
+  const flush = () => {
+    if (cur.length === 0) return;
+    const laneCount = cur.reduce((m, b) => Math.max(m, b.laneIndex + 1), 0);
+    clusters.push({
+      startSlot: curStart,
+      endSlot: curEnd,
+      laneCount,
+      hasSession: cur.some((b) => b.isSession),
+      blocks: cur,
+    });
+    cur = [];
+    curStart = -1;
+    curEnd = -1;
+  };
+
+  for (const block of sorted) {
+    const start = block.slotIndex;
+    const end = block.slotIndex + block.slotSpan;
+    if (cur.length > 0 && start >= curEnd) flush();
+    const used = new Set(
+      cur
+        .filter((b) => b.slotIndex + b.slotSpan > start)
+        .map((b) => b.laneIndex),
+    );
+    let lane = 0;
+    while (used.has(lane)) lane += 1;
+    cur.push({ ...block, laneIndex: lane });
+    if (curStart === -1) curStart = start;
+    curEnd = Math.max(curEnd, end);
+  }
+  flush();
+  return clusters;
 }
 
 interface WeeklyGridProps {
@@ -27,19 +101,36 @@ interface WeeklyGridProps {
   blocks: GridBlock[];
 }
 
-/** 슬롯 1칸 높이(px). */
-const SLOT_HEIGHT = 28;
-const TIME_COL_WIDTH = 56;
+const TIME_COL_WIDTH = 64;
+/** 이벤트(일정) 박스 1개의 고정 높이(px). 겹쳐도 이 크기를 유지한다. */
+const EVENT_HEIGHT = 42;
+/** 겹쳐 쌓인 이벤트 사이 간격(px). */
+const LANE_GAP = 4;
+/** 진행 박스와 이벤트 사이 안쪽 여백(px). */
+const BOX_PAD = 5;
+/** 진행 박스와 슬롯 경계선 사이 여백(px). 박스가 시간 칸을 넘지 않게 한다. */
+const CELL_PAD = 4;
+/** 한 시간대(슬롯)에 세로로 쌓을 이벤트 최대 개수 상한. */
+const MAX_LANES = 5;
+/** 현재 시각 라인 갱신 주기(ms). */
+const NOW_TICK_MS = 30_000;
 
 /**
  * 공용 주간 시간대 그리드.
- * 7일 x 30분 슬롯 격자에 절대 위치로 블록을 배치한다.
- * 예약 캘린더(3.2)·멘토 스케줄(3.3)이 공유한다.
+ * 같은 시간대 겹침은 이벤트 박스 크기를 유지한 채 세로로 쌓고,
+ * 슬롯(시간 칸) 높이를 최대 겹침 수에 맞춰 키운다. 진행이 있는 시간대는 박스로 묶는다.
  */
 export default function WeeklyGrid({ weekStart, blocks }: WeeklyGridProps) {
   const days = getWeekDays(weekStart);
   const timeLabels = getTimeLabels();
-  const gridHeight = SLOTS_PER_DAY * SLOT_HEIGHT;
+
+  // 현재 시각(라인·라벨용). 30초마다 갱신해 라인이 움직이도록 한다.
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), NOW_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+  const nowIndicator = getNowIndicator(weekStart, now);
 
   // 주 범위(월~일) 밖 블록은 표시하지 않는다.
   const visibleBlocks = blocks.filter(
@@ -50,23 +141,81 @@ export default function WeeklyGrid({ weekStart, blocks }: WeeklyGridProps) {
       b.slotIndex < SLOTS_PER_DAY,
   );
 
+  // 요일별 클러스터.
+  const dayClustersList = days.map((_, di) =>
+    layoutDayClusters(visibleBlocks.filter((b) => b.dayIndex === di)),
+  );
+
+  // 슬롯 높이 = 그 주의 최대 동시 진행 개수만큼 이벤트가 들어가도록 키운다.
+  // 박스 여백(BOX_PAD)·셀 여백(CELL_PAD)까지 포함해, 진행 박스가 칸을 넘지 않게 한다.
+  const maxLanes = Math.min(
+    MAX_LANES,
+    Math.max(1, ...dayClustersList.flat().map((c) => c.laneCount)),
+  );
+  const slotHeight =
+    2 * CELL_PAD +
+    2 * BOX_PAD +
+    maxLanes * EVENT_HEIGHT +
+    (maxLanes - 1) * LANE_GAP;
+  const gridHeight = SLOTS_PER_DAY * slotHeight;
+
+  // 이벤트(레인) 실제 top 좌표. 박스·이벤트가 이 값을 공유해 여백이 어긋나지 않는다.
+  const eventTop = (b: LaidBlock) =>
+    b.slotIndex * slotHeight +
+    CELL_PAD +
+    BOX_PAD +
+    b.laneIndex * (EVENT_HEIGHT + LANE_GAP);
+
+  const sessionCounts = dayClustersList.map((clusters) =>
+    clusters.reduce(
+      (n, c) => n + c.blocks.filter((b) => b.isSession).length,
+      0,
+    ),
+  );
+  const weekTotal = sessionCounts.reduce((a, b) => a + b, 0);
+
   return (
-    <div className="overflow-x-auto">
-      <div className="min-w-[720px]">
+    <div className="border-neutral-90 overflow-x-auto rounded-lg border">
+      <div className="min-w-[920px]">
+        {/* 현재 날짜·시각 + 이번 주 총 진행 건수 */}
+        <div className="border-neutral-90 flex items-center justify-between gap-2 border-b bg-white px-3 py-2">
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-xxsmall12 text-neutral-40">현재</span>
+            <span className="text-xsmall14 text-neutral-0 font-semibold">
+              {formatNowLabel(now)}
+            </span>
+          </div>
+          <span className="text-xsmall14 text-neutral-40">
+            이번 주 진행{' '}
+            <span className="font-semibold text-indigo-600">{weekTotal}</span>건
+          </span>
+        </div>
+
         {/* 요일 헤더 */}
         <div
-          className="border-neutral-80 grid border-b"
-          style={{
-            gridTemplateColumns: `${TIME_COL_WIDTH}px repeat(7, 1fr)`,
-          }}
+          className="border-neutral-85 bg-neutral-95 grid border-b"
+          style={{ gridTemplateColumns: `${TIME_COL_WIDTH}px repeat(7, 1fr)` }}
         >
           <div />
-          {days.map((day) => (
+          {days.map((day, dayIndex) => (
             <div
               key={day}
-              className="text-xxsmall12 text-neutral-0 py-2 text-center font-semibold"
+              className={twMerge(
+                'text-xsmall14 py-2 text-center font-semibold',
+                dayIndex === 5
+                  ? 'text-blue-600'
+                  : dayIndex === 6
+                    ? 'text-red-500'
+                    : 'text-neutral-0',
+              )}
             >
-              {formatDayHeader(day)}
+              <div>{formatDayHeader(day)}</div>
+              {sessionCounts[dayIndex] > 0 && (
+                <div className="text-xxsmall12 mt-0.5 font-medium text-indigo-600">
+                  진행 {sessionCounts[dayIndex]}
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -74,60 +223,100 @@ export default function WeeklyGrid({ weekStart, blocks }: WeeklyGridProps) {
         {/* 본문: 시간축 + 7개 요일 컬럼 */}
         <div
           className="grid"
-          style={{
-            gridTemplateColumns: `${TIME_COL_WIDTH}px repeat(7, 1fr)`,
-          }}
+          style={{ gridTemplateColumns: `${TIME_COL_WIDTH}px repeat(7, 1fr)` }}
         >
-          {/* 시간축 */}
+          {/* 시간축 — 정시 라벨만 표시해 시야를 정리한다. */}
           <div className="relative" style={{ height: gridHeight }}>
-            {timeLabels.map((label, i) => (
-              <div
-                key={label}
-                className="text-xxsmall12 text-neutral-40 absolute right-1 -translate-y-1/2"
-                style={{ top: i * SLOT_HEIGHT }}
-              >
-                {label}
-              </div>
-            ))}
+            {timeLabels.map((label, i) =>
+              i % 2 === 0 ? (
+                <div
+                  key={label}
+                  className="text-xxsmall12 text-neutral-40 absolute right-2 -translate-y-1/2 font-medium"
+                  style={{ top: i * slotHeight }}
+                >
+                  {label}
+                </div>
+              ) : null,
+            )}
           </div>
 
           {/* 요일별 컬럼 */}
-          {days.map((day, dayIndex) => (
-            <div
-              key={day}
-              className="border-neutral-90 relative border-l"
-              style={{ height: gridHeight }}
-            >
-              {/* 슬롯 가이드 라인 */}
-              {timeLabels.map((label, i) => (
-                <div
-                  key={label}
-                  className="border-neutral-95 absolute inset-x-0 border-t"
-                  style={{ top: i * SLOT_HEIGHT }}
-                />
-              ))}
-
-              {/* 블록 */}
-              {visibleBlocks
-                .filter((b) => b.dayIndex === dayIndex)
-                .map((b) => (
+          {days.map((day, dayIndex) => {
+            const clusters = dayClustersList[dayIndex];
+            const isWeekend = dayIndex === 5 || dayIndex === 6;
+            return (
+              <div
+                key={day}
+                className={twMerge(
+                  'border-neutral-90 relative border-l',
+                  isWeekend && 'bg-neutral-95',
+                )}
+                style={{ height: gridHeight }}
+              >
+                {/* 슬롯 가이드 라인: 정시는 진하게, 30분은 옅게 */}
+                {timeLabels.map((label, i) => (
                   <div
-                    key={b.key}
+                    key={label}
                     className={twMerge(
-                      'absolute inset-x-0.5 overflow-hidden rounded border px-1 py-0.5',
-                      'text-xxsmall12 leading-tight',
-                      b.className,
+                      'absolute inset-x-0 border-t',
+                      i % 2 === 0 ? 'border-neutral-85' : 'border-neutral-95',
                     )}
-                    style={{
-                      top: b.slotIndex * SLOT_HEIGHT,
-                      height: b.slotSpan * SLOT_HEIGHT - 2,
-                    }}
-                  >
-                    {b.content}
-                  </div>
+                    style={{ top: i * slotHeight }}
+                  />
                 ))}
-            </div>
-          ))}
+
+                {/* 진행 박스 — 같은 시간대 묶음을 한 번 더 상자로 감싸 진행임을 표시.
+                    이벤트 실제 위치 기준으로 상하좌우 동일 여백을 준다. */}
+                {clusters
+                  .filter((c) => c.hasSession)
+                  .map((c) => {
+                    const tops = c.blocks.map(eventTop);
+                    const boxTop = Math.min(...tops) - BOX_PAD;
+                    const boxBottom =
+                      Math.max(...tops) + EVENT_HEIGHT + BOX_PAD;
+                    return (
+                      <div
+                        key={`box-${c.startSlot}`}
+                        className="pointer-events-none absolute inset-x-1 z-0 rounded-lg border-2 border-indigo-300 bg-indigo-50/50"
+                        style={{ top: boxTop, height: boxBottom - boxTop }}
+                      />
+                    );
+                  })}
+
+                {/* 이벤트 박스 — 고정 크기로 세로로 쌓는다 */}
+                {clusters.flatMap((c) =>
+                  c.blocks.map((b) => (
+                    <div
+                      key={b.key}
+                      onClick={b.onClick}
+                      title={b.title}
+                      className={twMerge(
+                        'absolute inset-x-2 z-10 flex flex-col justify-center overflow-hidden rounded-md border-2 px-2 py-0.5',
+                        'text-xxsmall12 leading-tight',
+                        b.onClick &&
+                          'cursor-pointer transition hover:opacity-80',
+                        b.className,
+                      )}
+                      style={{ top: eventTop(b), height: EVENT_HEIGHT }}
+                    >
+                      {b.content}
+                    </div>
+                  )),
+                )}
+
+                {/* 현재 시각 라인(오늘 컬럼에만) */}
+                {nowIndicator && nowIndicator.dayIndex === dayIndex && (
+                  <div
+                    className="pointer-events-none absolute inset-x-0 z-20 flex items-center"
+                    style={{ top: nowIndicator.slotOffset * slotHeight }}
+                  >
+                    <span className="h-2 w-2 -translate-x-1/2 rounded-full bg-red-500" />
+                    <span className="flex-1 border-t-2 border-red-500" />
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/apps/admin/src/pages/challenge/feedback-operation/live-feedback/weekly-calendar/weekUtils.ts
+++ b/apps/admin/src/pages/challenge/feedback-operation/live-feedback/weekly-calendar/weekUtils.ts
@@ -113,3 +113,36 @@ export function formatWeekLabel(weekStart: string): string {
 export function formatDayHeader(day: string): string {
   return dayjs(day).format('M/D ddd');
 }
+
+export interface NowIndicator {
+  /** 0=월 ... 6=일 */
+  dayIndex: number;
+  /** 그리드 시작 시각(GRID_START_HOUR) 기준 슬롯 단위 오프셋(소수 가능). */
+  slotOffset: number;
+}
+
+/**
+ * 현재 시각이 표시 주와 그리드 시간 범위(09~22시) 안이면 위치를, 아니면 null 을 반환한다.
+ * 호출부에서 이 위치에 "지금" 라인을 그린다.
+ */
+export function getNowIndicator(
+  weekStart: string,
+  now: Date,
+): NowIndicator | null {
+  const monday = dayjs(weekStart).startOf('day');
+  const current = dayjs(now);
+  const dayIndex = current.startOf('day').diff(monday, 'day');
+  if (dayIndex < 0 || dayIndex > 6) return null;
+
+  const minutesFromStart =
+    current.hour() * 60 + current.minute() - GRID_START_HOUR * 60;
+  const totalMinutes = (GRID_END_HOUR - GRID_START_HOUR) * 60;
+  if (minutesFromStart < 0 || minutesFromStart > totalMinutes) return null;
+
+  return { dayIndex, slotOffset: minutesFromStart / SLOT_MINUTES };
+}
+
+/** 현재 날짜·시각 라벨(예: 2026.07.23 (목) 14:32). */
+export function formatNowLabel(now: Date): string {
+  return dayjs(now).format('YYYY.MM.DD (ddd) HH:mm');
+}


### PR DESCRIPTION
## 요약
어드민 피드백운영 LIVE 피드백 탭(예약 관리·멘토 스케줄) 성능·정확성·가독성 개편.

## 변경
- **탭 라우팅**: 상·하위 탭 상태를 URL(`?tab`,`?sub`)로 유지 → 새로고침해도 보던 탭 유지, F5 시 공지 탭 리셋에 따른 불필요 재조회 방지
- **멘토 목록 버그 수정**: `/admin/user?isMentor`가 전체 유저를 반환하던 문제 → 전용 `/admin/user/mentor`로 교체(멘토 스케줄·예약 드롭다운 양쪽)
- **멘토 스케줄**: 태그 선택형으로 멘토 슬롯 병렬 호출(N+1) 제거(선택 시 1명만 조회), 예정 예약 많은 순 정렬, 이름 검색
- **캘린더**: 예약 블록에 챌린지·회차·멘토·멘티 표시, 같은 시간 겹침 세로 쌓기 + 진행 박스, 요일별/주간 진행 건수, 현재 시각 라인, 오픈 슬롯 아주 연한 회색
- **상호작용**: 캘린더/리스트 토글, 캘린더 클릭 → 상세, 상세 → 예약 변경 전환

## 참고
- "N회차"는 현재 서버 `th`(라이브 피드백 순번)라 실제 미션 회차와 다를 수 있어 화면 상단에 안내 메모 노출. BE `missionTh` 반영 시 교체 예정(별도 BE PR).
- admin typecheck 통과(기존 에러 외 신규 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)