### PR TITLE
LC-3165 멘토 마이페이지 구글 켈렌더 일정 추가

### DIFF
--- a/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
+++ b/apps/mentor/src/pages/schedule/modal/LiveFeedbackReservationModal.tsx
@@ -28,6 +28,7 @@ import {
 import { isNotionUrl } from '@/pages/feedback/utils/notion';
 
 import type { PeriodBarData } from '../types';
+import { createGoogleCalendarUrl } from '../utils/googleCalendar';
 import JitsiEmbedModal from './JitsiEmbedModal';
 
 /** 좌측 사이드바 하단 가이드 링크 (세로 정렬). */
@@ -323,6 +324,28 @@ const LiveFeedbackReservationModal = ({
     selectedBar.liveFeedback?.startTime,
     selectedBar.liveFeedback?.endTime,
   );
+
+  // 구글 캘린더 "일정 추가" 프리필 링크 — 멘토가 예약 세션을 자기 캘린더에 담도록.
+  // 회의 링크는 웹 라이브 피드백 입장 URL(/live-feedback/mentor/{feedbackId})을 사용.
+  const round = roundTh ?? selectedBar.th;
+  const liveEntryUrl =
+    feedbackId != null
+      ? `${import.meta.env.VITE_WEB_URL ?? ''}/live-feedback/mentor/${feedbackId}`
+      : null;
+  const googleCalendarUrl =
+    startIso && endIso
+      ? createGoogleCalendarUrl({
+          // 캘린더 칩에서 잘려도 "누구와의 일정"인지 남도록 멘티 이름을 앞쪽에 둔다.
+          title: `[렛츠커리어] ${selectedMentee.name} 멘티 라이브 피드백 · ${selectedMentee.challengeTitle} ${round}차`,
+          startAt: startIso,
+          endAt: endIso,
+          // 위치(location)는 지도 핀으로 렌더돼 지저분하므로 쓰지 않고,
+          // 설명(details)에 입장 링크만 한 줄로 넣는다(구글이 자동 하이퍼링크 처리).
+          details: liveEntryUrl
+            ? `라이브 피드백 입장 링크\n${liveEntryUrl}`
+            : undefined,
+        })
+      : null;
 
   return (
     <>
@@ -622,6 +645,18 @@ const LiveFeedbackReservationModal = ({
           }
           actions={
             <div className="flex items-center gap-3">
+              {/* 구글 캘린더에 추가 — 예약 시각이 있으면 항상 노출(입장 게이트와 무관).
+                  프리필 링크라 새 탭에서 열려 사용자가 저장을 눌러 등록한다. */}
+              {googleCalendarUrl && (
+                <a
+                  href={googleCalendarUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary bg-primary-10 hover:bg-primary-15 rounded-[4px] px-4 py-2 text-sm font-semibold transition-colors"
+                >
+                  구글 캘린더에 추가
+                </a>
+              )}
               {/* 라이브 입장하기 — 시작 20분 전(LIVE_ENTER_LEAD_MS)부터 종료 전까지 활성.
                   데드락 방지: meetingUrl 이 없어도(아직 회의실 미생성) 멘토는 입장 가능.
                   클릭 시 handleEnterLive 가 헬스체크 + meeting-url PATCH 로 회의실을 생성한다.

--- a/apps/mentor/src/pages/schedule/utils/googleCalendar.ts
+++ b/apps/mentor/src/pages/schedule/utils/googleCalendar.ts
@@ -1,0 +1,47 @@
+/** 구글 캘린더 "일정 추가"(TEMPLATE) 프리필 링크 생성 유틸. */
+
+export interface GoogleCalendarEvent {
+  title: string;
+  /** ISO datetime. 오프셋/Z 가 없으면 KST(+09:00)로 간주해 UTC 로 변환한다. */
+  startAt: string;
+  endAt: string;
+  details?: string;
+  location?: string;
+}
+
+/**
+ * ISO 문자열을 구글 캘린더 dates 파라미터(YYYYMMDDTHHMMSSZ, UTC)로 변환.
+ *
+ * BE 가 내려주는 예약 시각은 타임존 표기가 없는 KST(naive)라, 오프셋/Z 가 없으면
+ * +09:00 로 간주한다. 이렇게 하면 멘토 브라우저 타임존과 무관하게 항상 동일한
+ * 절대 시각으로 등록된다(UTC Z 로 순간이 고정되므로 ctz 파라미터가 불필요).
+ */
+function toGoogleCalendarUtc(iso: string): string {
+  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(iso);
+  const date = new Date(hasTimezone ? iso : `${iso}+09:00`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`올바르지 않은 날짜입니다: ${iso}`);
+  }
+  return date
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * 구글 캘린더 일정 추가 화면으로 여는 프리필 URL 을 만든다.
+ * 링크를 열면 값이 채워진 "새 일정" 화면이 뜨고, 저장은 사용자가 수동으로 누른다.
+ */
+export function createGoogleCalendarUrl(event: GoogleCalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${toGoogleCalendarUtc(event.startAt)}/${toGoogleCalendarUtc(
+      event.endAt,
+    )}`,
+  });
+  if (event.details) params.set('details', event.details);
+  if (event.location) params.set('location', event.location);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}

--- a/apps/web/src/domain/live-feedback/LiveFeedbackEntryPage.tsx
+++ b/apps/web/src/domain/live-feedback/LiveFeedbackEntryPage.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { LiveRole } from './hooks/liveRole';
 import { useLiveEntry } from './hooks/useLiveEntry';
+import AddToCalendarButton from './ui/AddToCalendarButton';
 import EnterLiveButton from './ui/EnterLiveButton';
 import LiveFeedbackModal from './ui/LiveFeedbackModal';
 import LoginGate from './ui/LoginGate';
@@ -65,6 +66,24 @@ export default function LiveFeedbackEntryPage({ feedbackId, role }: Props) {
     );
   }
 
+  // 상대방(멘토 화면이면 멘티, 멘티 화면이면 멘토) 호칭·이름.
+  const counterpartLabel = role === 'MENTOR' ? '멘티' : '멘토';
+  const counterpartName =
+    (role === 'MENTOR' ? feedbackInfo?.menteeName : feedbackInfo?.mentorName) ??
+    undefined;
+
+  // 캘린더 일정 제목 — 캘린더 칩에서 잘려도 "누구와의 일정"인지 남도록 상대방 이름을
+  // 브랜드 태그 바로 뒤(앞쪽)에 둔다. 프로그램·회차는 뒤로 보내 잘려도 무방하게.
+  const calendarTitle = [
+    '[렛츠커리어]',
+    counterpartName ? `${counterpartName} ${counterpartLabel}` : null,
+    '라이브 피드백',
+    feedbackInfo?.programTitle ? `· ${feedbackInfo.programTitle}` : null,
+    feedbackInfo?.missionTh != null ? `${feedbackInfo.missionTh}차` : null,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <main className="flex min-h-[80vh] w-full items-center justify-center px-5 py-10">
       <div className="flex w-full max-w-[420px] flex-col gap-5">
@@ -75,12 +94,8 @@ export default function LiveFeedbackEntryPage({ feedbackId, role }: Props) {
               ? `${feedbackInfo.missionTh}회차`
               : undefined
           }
-          counterpartLabel={role === 'MENTOR' ? '멘티' : '멘토'}
-          counterpartName={
-            (role === 'MENTOR'
-              ? feedbackInfo?.menteeName
-              : feedbackInfo?.mentorName) ?? undefined
-          }
+          counterpartLabel={counterpartLabel}
+          counterpartName={counterpartName}
           startDate={feedbackInfo?.startDate}
           endDate={feedbackInfo?.endDate}
           role={role}
@@ -93,6 +108,13 @@ export default function LiveFeedbackEntryPage({ feedbackId, role }: Props) {
           disabled={!feedbackInfo}
           isPreparing={isPreparing}
           onEnter={enter}
+        />
+
+        {/* 구글 캘린더에 추가 — 입장 버튼 아래. 시작 1시간 전부터 자동으로 숨겨진다. */}
+        <AddToCalendarButton
+          title={calendarTitle}
+          startDate={feedbackInfo?.startDate}
+          endDate={feedbackInfo?.endDate}
         />
       </div>
 

--- a/apps/web/src/domain/live-feedback/ui/AddToCalendarButton.tsx
+++ b/apps/web/src/domain/live-feedback/ui/AddToCalendarButton.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { createGoogleCalendarUrl } from '../utils/googleCalendar';
+
+interface Props {
+  /** 캘린더 일정 제목 */
+  title: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/** 구글 캘린더 아이콘(달력 + 체크). */
+const CalendarIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden>
+    <rect
+      x="2.5"
+      y="3"
+      width="11"
+      height="10.5"
+      rx="1.5"
+      stroke="currentColor"
+      strokeWidth="1.2"
+    />
+    <path
+      d="M2.5 6h11M5.5 2v2M10.5 2v2"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M6 9.8l1.4 1.4 2.8-2.9"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+/** 세션 시작 1시간 전부터는 캘린더 추가 버튼을 숨긴다(이후엔 입장 버튼/카운트다운이 안내). */
+const HIDE_BEFORE_START_MS = 60 * 60 * 1000;
+
+/**
+ * 예약된 라이브 피드백을 구글 캘린더에 담는 버튼(입장 버튼 아래에 표시).
+ *
+ * - 세션 시작 1시간 전부터는 숨긴다 — 임박한 시점엔 아래 입장 버튼/카운트다운이 안내한다.
+ * - 프리필 링크라 새 탭에서 열려 사용자가 저장을 눌러 등록한다.
+ * - 캘린더 일정의 링크로는 현재 입장 페이지 URL 을 넣어, 알림에서 바로 입장할 수 있게 한다.
+ * - window 접근·시각 판정이 클라이언트에서만 확정되므로 마운트 후에만 렌더한다(하이드레이션 안전).
+ */
+const AddToCalendarButton = ({ title, startDate, endDate }: Props) => {
+  const [mounted, setMounted] = useState(false);
+  const [now, setNow] = useState(0);
+
+  useEffect(() => {
+    setMounted(true);
+    setNow(Date.now());
+    // 숨김 시점에 맞춰 갱신하기 위한 저빈도 갱신(분 단위면 충분).
+    const timer = setInterval(() => setNow(Date.now()), 60 * 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!mounted || !startDate || !endDate) return null;
+
+  const start = new Date(startDate).getTime();
+  if (Number.isNaN(start) || now >= start - HIDE_BEFORE_START_MS) return null;
+
+  const entryUrl = `${window.location.origin}${window.location.pathname}`;
+  const url = createGoogleCalendarUrl({
+    title,
+    startAt: startDate,
+    endAt: endDate,
+    // 위치(location) 필드는 지도 핀으로 렌더돼 URL 이 지저분하므로 쓰지 않고,
+    // 설명(details)에 입장 링크만 한 줄로 넣는다(구글이 자동 하이퍼링크 처리).
+    details: `라이브 피드백 입장 링크\n${entryUrl}`,
+  });
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-small16 text-primary bg-primary-10 hover:bg-primary-15 flex min-h-[52px] w-full items-center justify-center gap-2 rounded-md px-4 py-3 font-semibold transition-colors"
+    >
+      <CalendarIcon />
+      구글 캘린더에 추가
+    </a>
+  );
+};
+
+export default AddToCalendarButton;

--- a/apps/web/src/domain/live-feedback/ui/EnterLiveButton.tsx
+++ b/apps/web/src/domain/live-feedback/ui/EnterLiveButton.tsx
@@ -105,7 +105,7 @@ const EnterLiveButton = ({
       type="button"
       disabled={isDisabled}
       onClick={onEnter}
-      className="text-small16 bg-primary disabled:bg-neutral-80 flex min-h-[52px] w-full items-center justify-center rounded-md px-4 py-3 font-semibold text-white disabled:cursor-not-allowed disabled:text-neutral-50"
+      className="text-small16 bg-primary disabled:bg-neutral-85 disabled:text-neutral-45 flex min-h-[52px] w-full items-center justify-center rounded-md px-4 py-3 font-semibold text-white disabled:cursor-not-allowed"
     >
       {isPreparing ? '회의실 준비 중...' : state.label}
     </button>

--- a/apps/web/src/domain/live-feedback/utils/googleCalendar.ts
+++ b/apps/web/src/domain/live-feedback/utils/googleCalendar.ts
@@ -1,0 +1,47 @@
+/** 구글 캘린더 "일정 추가"(TEMPLATE) 프리필 링크 생성 유틸. */
+
+export interface GoogleCalendarEvent {
+  title: string;
+  /** ISO datetime. 오프셋/Z 가 없으면 KST(+09:00)로 간주해 UTC 로 변환한다. */
+  startAt: string;
+  endAt: string;
+  details?: string;
+  location?: string;
+}
+
+/**
+ * ISO 문자열을 구글 캘린더 dates 파라미터(YYYYMMDDTHHMMSSZ, UTC)로 변환.
+ *
+ * BE 가 내려주는 예약 시각은 타임존 표기가 없는 KST(naive)라, 오프셋/Z 가 없으면
+ * +09:00 로 간주한다. 이렇게 하면 브라우저 타임존과 무관하게 항상 동일한 절대
+ * 시각으로 등록된다(UTC Z 로 순간이 고정되므로 ctz 파라미터가 불필요).
+ */
+function toGoogleCalendarUtc(iso: string): string {
+  const hasTimezone = /([zZ]|[+-]\d{2}:\d{2})$/.test(iso);
+  const date = new Date(hasTimezone ? iso : `${iso}+09:00`);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`올바르지 않은 날짜입니다: ${iso}`);
+  }
+  return date
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * 구글 캘린더 일정 추가 화면으로 여는 프리필 URL 을 만든다.
+ * 링크를 열면 값이 채워진 "새 일정" 화면이 뜨고, 저장은 사용자가 수동으로 누른다.
+ */
+export function createGoogleCalendarUrl(event: GoogleCalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${toGoogleCalendarUtc(event.startAt)}/${toGoogleCalendarUtc(
+      event.endAt,
+    )}`,
+  });
+  if (event.details) params.set('details', event.details);
+  if (event.location) params.set('location', event.location);
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}


### PR DESCRIPTION
## 개요
멘토/멘티가 예약된 라이브 피드백 세션을 **구글 캘린더에 추가**할 수 있는 버튼을 추가합니다. (프리필 링크 방식 — 순수 프론트, 백엔드/OAuth 불필요)

## 변경 위치
- **웹 입장 페이지** (`LiveFeedbackEntryPage`): 입장 버튼 아래에 "구글 캘린더에 추가" 노출. 세션 **시작 1시간 전부터 자동 숨김** → 이후 기존 입장 버튼 로직이 이어받음. (멘토·멘티 공용)
- **멘토 예약 상세 모달** (`LiveFeedbackReservationModal`): 피드백 **캘린더·내역** 양쪽에서 공유하는 모달이라 버튼 하나로 두 진입점 커버.

## 구현 노트
- `createGoogleCalendarUrl` 유틸: BE 가 주는 타임존 없는 KST(naive) 시각을 `+09:00`로 간주해 UTC(`...Z`)로 변환 → 브라우저 타임존 무관하게 동일 절대 시각으로 등록.
- 캘린더 **제목은 상대방(멘티) 이름을 앞쪽**에 배치 → 캘린더 칩에서 잘려도 "누구와의 일정"인지 유지.
- 회의 링크는 웹 입장 URL(`/live-feedback/{role}/{feedbackId}`)을 **설명(details)** 에 포함(위치 필드는 지도 핀으로 지저분해 제외).
- 비활성 입장 버튼 색(`neutral-85`)을 캘린더 버튼(`primary-10`)과 밸런스 맞게 조정.

## 검증
- 타입체크 / prettier / eslint 통과 (web·mentor)
- 웹 live-feedback 테스트 22개, 멘토 스케줄 모달 테스트 12개 통과

## 참고 (한계)
- 프리필 링크라 **자동 등록이 아니라** 사용자가 캘린더 화면에서 "저장"을 눌러야 등록됨(수동).
- 구글 Meet 회의 자동 첨부/이미지 삽입은 구글 캘린더 프리필 링크로는 불가(각각 Calendar API+OAuth 필요 / 캘린더 자체 미지원).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [LC-3165]

[LC-3165]:https://letscareer-team.atlassian.net/browse/LC-3165


[LC-3165]: https://letscareer-team.atlassian.net/browse/LC-3165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ