### PR TITLE
LC-3174 하반기 멤버쉽 대기업 서류 합격률 2배 vod 주소 변경

### DIFF
--- a/apps/web/src/domain/membership/data/links.ts
+++ b/apps/web/src/domain/membership/data/links.ts
@@ -10,7 +10,7 @@ export const VOD_DETAIL_URL =
 
 /**
  * VOD 훅 섹션 자소서 카드 "VOD 확인하기" 이동 대상 —
- * [🎁무료] 대기업 서류 합격률 2배 높이는 필살기 경험과 마스터 자소서 작성법.
+ * [렛츠 VOD] 대기업 서류 합격률 2배 높이는 필살기 경험과 마스터 자소서 작성법.
  */
 export const VOD_JASOSEO_URL =
-  'https://www.letscareer.co.kr/program/live/101/%5B%F0%9F%8E%81%EB%AC%B4%EB%A3%8C%5D-%EB%8C%80%EA%B8%B0%EC%97%85-%EC%84%9C%EB%A5%98-%ED%95%A9%EA%B2%A9%EB%A5%A0-2%EB%B0%B0-%EB%86%92%EC%9D%B4%EB%8A%94--%ED%95%84%EC%82%B4%EA%B8%B0-%EA%B2%BD%ED%97%98%EA%B3%BC-%EB%A7%88%EC%8A%A4%ED%84%B0-%EC%9E%90%EC%86%8C%EC%84%9C-%EC%9E%91%EC%84%B1%EB%B2%95';
+  'https://www.letscareer.co.kr/program/vod/33/%5B%EB%A0%9B%EC%B8%A0-vod%5D-%EB%8C%80%EA%B8%B0%EC%97%85-%EC%84%9C%EB%A5%98-%ED%95%A9%EA%B2%A9%EB%A5%A0-2%EB%B0%B0-%EB%86%92%EC%9D%B4%EB%8A%94-%ED%95%84%EC%82%B4%EA%B8%B0-%EA%B2%BD%ED%97%98%EA%B3%BC-%EB%A7%88%EC%8A%A4%ED%84%B0-%EC%9E%90%EC%86%8C%EC%84%9C-%EC%9E%91%EC%84%B1%EB%B2%95';


### PR DESCRIPTION
## 연관 작업

<!-- (하단에 자동으로 브런치와 LC 티켓이 붙게 됩니다.) -->

- [LC-3174]

[LC-3174]:https://letscareer-team.atlassian.net/browse/LC-3174

## 변경 사항

하반기 멤버십 랜딩 VOD 훅 섹션의 **첫 번째 카드**(`[렛츠 VOD] 대기업 서류 합격률 2배 높이는 필살기 경험과 마스터 자소서 작성법`)의 `VOD 확인하기` 버튼 이동 대상을 교체했습니다.

| | URL |
|---|---|
| 기존 | `/program/live/101/[🎁무료]-대기업-서류-합격률-2배-...` (라이브 클래스) |
| 변경 | `/program/vod/33/[렛츠-vod]-대기업-서류-합격률-2배-...` (VOD) |

- `apps/web/src/domain/membership/data/links.ts` 의 `VOD_JASOSEO_URL` 만 수정
- 슬러그 변경(`[🎁무료]` → `[렛츠 VOD]`)에 맞춰 JSDoc 프로그램명도 갱신

## 영향 범위

- 외부 링크는 `data/links.ts` 단일 출처로 관리되고 있어 수정 지점은 상수 1곳입니다.
- 해당 상수는 `data/vodHook.ts` 의 첫 번째 카드 `detailUrl` 에서만 참조합니다. 두 번째 카드는 `VOD_DETAIL_URL`(`/program/vod/32`)을 그대로 사용하므로 영향 없습니다.
- 렌더링은 `section/VodHookSection.tsx` 의 `href={card.detailUrl}` 로, 컴포넌트 수정은 불필요했습니다.

## 확인

- [x] Prettier 포맷 검사 통과
- [ ] 배포 후 `VOD 확인하기` 클릭 시 `/program/vod/33` 상세로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LC-3174]: https://letscareer-team.atlassian.net/browse/LC-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LC-3174]: https://letscareer-team.atlassian.net/browse/LC-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ