### PR TITLE
feat(mentor): 오픈 설정 잠금 UI·미리보기 개선, 오픈 현황 줄바꿈 수정, 사이드바 오픈중 배지

### DIFF
--- a/apps/mentor/src/layout/MentorSidebar.tsx
+++ b/apps/mentor/src/layout/MentorSidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import LiveMentoringOpenBadge from '@/pages/live-mentoring/ui/LiveMentoringOpenBadge';
 import NotificationBell from '@/pages/notification/ui/NotificationBell';
 
 interface NavLeaf {
@@ -16,6 +17,8 @@ interface NavGroup {
   children: NavLeaf[];
   /** true 면 대주제 클릭으로 하위 항목을 열고 닫는 드롭다운으로 동작한다. */
   collapsible?: boolean;
+  /** true 면 그룹 이름 옆에 1대1 라이브 멘토링 오픈 상태 배지를 붙인다. */
+  showLiveMentoringStatus?: boolean;
 }
 
 type NavItem = NavLeaf | NavGroup;
@@ -45,6 +48,7 @@ const navItems: NavItem[] = [
     name: '1대1 라이브 멘토링',
     matchPrefix: '/live-mentoring',
     collapsible: true,
+    showLiveMentoringStatus: true,
     children: [
       { type: 'leaf', name: '오픈 설정', url: '/live-mentoring/open-settings' },
       {
@@ -173,6 +177,13 @@ export const MentorSidebar = ({ isOpen, onClose }: MentorSidebarProps) => {
                     ? 'text-primary font-semibold'
                     : 'text-neutral-40 font-medium'
                 }`;
+                // 이름 옆 상태 배지 — 오픈 중이 아니면 배지 컴포넌트가 스스로 null 을 낸다.
+                const groupLabel = (
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <span className="truncate">{item.name}</span>
+                    {item.showLiveMentoringStatus && <LiveMentoringOpenBadge />}
+                  </span>
+                );
                 return (
                   <li key={item.name}>
                     {isCollapsible ? (
@@ -180,9 +191,9 @@ export const MentorSidebar = ({ isOpen, onClose }: MentorSidebarProps) => {
                         type="button"
                         aria-expanded={expanded}
                         onClick={() => toggleGroup(item.name)}
-                        className={`${parentClass} flex w-full items-center justify-between`}
+                        className={`${parentClass} flex w-full items-center justify-between gap-2`}
                       >
-                        {item.name}
+                        {groupLabel}
                         <svg
                           width="16"
                           height="16"
@@ -201,7 +212,7 @@ export const MentorSidebar = ({ isOpen, onClose }: MentorSidebarProps) => {
                         </svg>
                       </button>
                     ) : (
-                      <p className={parentClass}>{item.name}</p>
+                      <p className={parentClass}>{groupLabel}</p>
                     )}
                     {expanded && (
                       <ul className="mt-0.5 flex flex-col">

--- a/apps/mentor/src/layout/__tests__/MentorSidebar.test.tsx
+++ b/apps/mentor/src/layout/__tests__/MentorSidebar.test.tsx
@@ -7,6 +7,11 @@ vi.mock('@/pages/notification/ui/NotificationBell', () => ({
   default: () => <div data-testid="notification-bell" />,
 }));
 
+// 오픈 상태 배지도 react-query 를 쓰므로 같은 이유로 모킹한다(사이드바는 provider 없이 렌더).
+vi.mock('@/pages/live-mentoring/ui/LiveMentoringOpenBadge', () => ({
+  default: () => null,
+}));
+
 import { MentorSidebar } from '../MentorSidebar';
 
 beforeAll(() => {

--- a/apps/mentor/src/pages/live-mentoring/__tests__/liveMentoringNav.test.tsx
+++ b/apps/mentor/src/pages/live-mentoring/__tests__/liveMentoringNav.test.tsx
@@ -7,6 +7,11 @@ vi.mock('@/pages/notification/ui/NotificationBell', () => ({
   default: () => <div data-testid="notification-bell" />,
 }));
 
+// 오픈 상태 배지도 react-query 를 쓰므로 같은 이유로 모킹한다(사이드바는 provider 없이 렌더).
+vi.mock('@/pages/live-mentoring/ui/LiveMentoringOpenBadge', () => ({
+  default: () => null,
+}));
+
 import { MentorSidebar } from '@/layout/MentorSidebar';
 
 beforeAll(() => {

--- a/apps/mentor/src/pages/live-mentoring/constants.ts
+++ b/apps/mentor/src/pages/live-mentoring/constants.ts
@@ -19,6 +19,43 @@ export const durationLabel = (durationMin: number): string =>
 export const formatPrice = (price: number): string =>
   `${price.toLocaleString('ko-KR')}원`;
 
+/*
+ * 아래 4개는 **웹 공개 카드와 픽셀 단위로 같은 미리보기**를 만들기 위한 포맷터다.
+ * 원본: apps/web/src/domain/live-mentoring/constants.ts
+ * 앱 간 코드를 공유하지 않는 규칙 때문에 의도적으로 복제했다 —
+ * 웹 카드 표기 규칙이 바뀌면 여기도 같이 고쳐야 미리보기가 거짓말을 하지 않는다.
+ */
+
+/** 카드 하단 바의 진행시간 표기 (예: "30분 / 60분"). */
+export const durationsLabel = (durations: number[]): string =>
+  durations.map(durationLabel).join(' / ');
+
+/** 카드 하단 바의 가격 표기 (예: "30,000원~"). 여러 진행시간이면 최저가라 물결을 붙인다. */
+export const cardPriceLabel = (durations: number[], price: number): string =>
+  `${formatPrice(price)}${durations.length > 1 ? '~' : ''}`;
+
+/** 카드 진행기간 표시 (예: "25.02.15 ~ 25.02.28"). 값이 없으면 "미정". */
+export const formatOpeningPeriod = (
+  start: string | null,
+  end: string | null,
+): string => {
+  const yymmdd = (iso: string | null) =>
+    iso ? iso.slice(2).split('-').join('.') : '미정';
+  return `${yymmdd(start)} ~ ${yymmdd(end)}`;
+};
+
+/**
+ * 카드 썸네일 좌상단 배지 — 대표 경력의 **직무**만 표기한다.
+ * (연차는 목록 응답으로 총 경력을 알 수 없어 웹 카드에서도 표기하지 않는다.)
+ */
+export const careerBadgeLabel = (
+  career: { job: string | null; position: string | null } | null,
+): string => career?.job ?? career?.position ?? '';
+
+/** 프로필 이미지가 없을 때 썸네일에 대신 넣는 문구. */
+export const imagePlaceholderTitle = (nickname: string): string =>
+  `${nickname} 멘토님의 멘토링`;
+
 /**
  * 대표 경력 한 줄 표시 (예: "네이버 · 프로덕트 기획").
  *

--- a/apps/mentor/src/pages/live-mentoring/open-settings/OpenSettingsPage.tsx
+++ b/apps/mentor/src/pages/live-mentoring/open-settings/OpenSettingsPage.tsx
@@ -227,15 +227,45 @@ const OpenSettingsPage = () => {
         </p>
       </header>
 
-      {/* 오픈 중에는 설정 전체를 블러 처리하고 상호작용을 막는다. */}
-      <div className="relative">
+      {/*
+        오픈 중 상태 배너.
+        오픈 중에도 멘토는 "내가 어떤 조건으로 열었는지" 확인해야 하므로 설정을 가리지 않고,
+        상태와 해제 방법만 상단에 알린다. 잠그는 대상은 화면이 아니라 입력이다.
+      */}
+      {isCurrentlyOpen && (
         <div
-          className={
-            isCurrentlyOpen
-              ? 'pointer-events-none select-none blur-[8px]'
-              : undefined
-          }
-          aria-hidden={isCurrentlyOpen}
+          role="status"
+          className="border-primary/20 bg-primary-10 flex flex-col gap-3 rounded-xl border px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex flex-col gap-1">
+            <span className="text-primary flex items-center gap-1.5 text-sm font-semibold">
+              <span
+                className="bg-primary h-1.5 w-1.5 rounded-full"
+                aria-hidden="true"
+              />
+              오픈 중
+            </span>
+            <p className="text-xs text-gray-600">
+              설정을 수정하려면 오픈을 닫아주세요. 진행 중인 예약은 유지됩니다.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleCloseOpen}
+            disabled={isPending}
+            className="border-primary text-primary hover:bg-primary shrink-0 rounded-lg border bg-white px-6 py-2.5 text-sm font-medium transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPending ? '처리 중...' : '오픈 닫기'}
+          </button>
+        </div>
+      )}
+
+      <div className="relative">
+        {/* 오픈 중에는 입력만 잠근다 — fieldset 이 자손 폼 컨트롤을 한 번에 비활성화하고
+            키보드 포커스에서도 빼준다(pointer-events-none 은 마우스만 막는다). */}
+        <fieldset
+          disabled={isCurrentlyOpen}
+          className="m-0 min-w-0 border-0 p-0"
         >
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
             {/* 좌: 설정 패널 */}
@@ -468,27 +498,8 @@ const OpenSettingsPage = () => {
               <OpenSettingsPreview settings={form} />
             </div>
           </div>
-        </div>
+        </fieldset>
       </div>
-
-      {/* 오픈 중 잠금 오버레이 — 좌측 네비를 제외한 콘텐츠 영역 정중앙에 오픈 닫기 버튼 */}
-      {isCurrentlyOpen && (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-white/40 backdrop-blur-sm lg:left-[296px]">
-          <div className="flex flex-col items-center gap-6">
-            <p className="rounded-md bg-white/95 px-6 py-3 text-base font-medium text-gray-700 shadow-lg">
-              오픈 중에는 설정을 수정할 수 없어요.
-            </p>
-            <button
-              type="button"
-              onClick={handleCloseOpen}
-              disabled={isPending}
-              className="bg-primary hover:bg-primary-hover rounded-2xl px-20 py-6 text-2xl font-bold text-white shadow-2xl transition-colors disabled:opacity-50"
-            >
-              {isPending ? '처리 중...' : '오픈 닫기'}
-            </button>
-          </div>
-        </div>
-      )}
 
       {/* 하단 버튼: 오픈 중이면 숨김. 변경사항 있으면 저장, 없으면 오픈하기. */}
       {!isCurrentlyOpen && (

--- a/apps/mentor/src/pages/live-mentoring/open-settings/__tests__/OpenSettingsPage.test.tsx
+++ b/apps/mentor/src/pages/live-mentoring/open-settings/__tests__/OpenSettingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -331,5 +331,52 @@ describe('OpenSettingsPage — 오픈 상태/버튼', () => {
     expect(
       screen.queryByRole('button', { name: '오픈하기' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('오픈 중이면 상단에 오픈 중 상태 배너를 노출한다', () => {
+    renderPage({ isOpen: true });
+    const banner = screen.getByRole('status');
+    expect(within(banner).getByText('오픈 중')).toBeInTheDocument();
+    expect(
+      within(banner).getByRole('button', { name: /오픈 닫기/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('오픈 중이 아니면 상태 배너를 렌더하지 않는다', () => {
+    renderPage();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  // 미리보기는 웹 공개 카드(MentorCard)를 복제한 것이라, 표기 규칙이 어긋나면
+  // 멘토가 실제와 다른 화면을 보고 오픈하게 된다. 핵심 표기만 고정한다.
+  it('미리보기가 공개 카드와 같은 표기 규칙을 따른다', () => {
+    renderPage({ durations: [30, 60], feedbackStartDate: '2026-07-14' });
+
+    // 진행시간은 "/"로 잇고, 여러 개면 최저가에 물결을 붙인다
+    expect(screen.getByText('30분 / 60분')).toBeInTheDocument();
+    expect(screen.getByText(/^[\d,]+원~$/)).toBeInTheDocument();
+    // 진행기간은 YY.MM.DD 형식
+    expect(screen.getByText('26.07.14 ~ 26.07.28')).toBeInTheDocument();
+    // 카드 제목은 타이틀 그대로 (미입력 시에만 닉네임 기반 문구로 폴백)
+    expect(screen.getByText('자소서 실전 첨삭 멘토링')).toBeInTheDocument();
+  });
+
+  it('미리보기 카드 제목은 타이틀이 비면 닉네임 기반 문구로 폴백한다', () => {
+    renderPage({ title: '' });
+    expect(screen.getByText('자소서장인의 1:1 멘토링')).toBeInTheDocument();
+  });
+
+  it('미리보기 진행기간은 날짜가 비면 미정으로 표시한다', () => {
+    renderPage({ feedbackStartDate: null, feedbackEndDate: null });
+    expect(screen.getByText('미정 ~ 미정')).toBeInTheDocument();
+  });
+
+  it('오픈 중에는 설정 입력이 비활성화되지만 값은 그대로 읽을 수 있다', () => {
+    renderPage({ isOpen: true, title: '자소서 실전 첨삭' });
+    // 화면을 가리지 않으므로 설정한 타이틀이 그대로 보인다
+    const titleInput = screen.getByDisplayValue('자소서 실전 첨삭');
+    expect(titleInput).toBeInTheDocument();
+    // 다만 fieldset disabled 로 입력은 잠긴다
+    expect(titleInput).toBeDisabled();
   });
 });

--- a/apps/mentor/src/pages/live-mentoring/open-settings/ui/OpenSettingsPreview.tsx
+++ b/apps/mentor/src/pages/live-mentoring/open-settings/ui/OpenSettingsPreview.tsx
@@ -3,17 +3,28 @@ import { getLowestPrice } from '@letscareer/mocks';
 import type { LiveMentoringSettings } from '@/api/live-mentoring/liveMentoringSchema';
 import {
   CATEGORY_LABELS,
-  durationLabel,
-  formatCareerPeriod,
-  formatPrice,
-  representativeCareerLabel,
+  cardPriceLabel,
+  careerBadgeLabel,
+  durationsLabel,
+  formatOpeningPeriod,
+  imagePlaceholderTitle,
 } from '../../constants';
 
 interface OpenSettingsPreviewProps {
   settings: LiveMentoringSettings;
 }
 
-/** 오픈 설정 요약 카드 미리보기 (공개 리스트 카드 형태 근사). */
+/**
+ * 오픈 설정 미리보기 — **멘티에게 보이는 공개 리스트 카드를 그대로 재현한다.**
+ *
+ * 원본: `apps/web/src/domain/live-mentoring/list/MentorCard.tsx`.
+ * 앱 간 컴포넌트를 공유하지 않는 규칙 때문에 마크업을 복제했다. 웹 카드가 바뀌면
+ * 여기도 같이 고쳐야 한다 — 미리보기가 실제와 다르면 없느니만 못하다.
+ *
+ * 원본과 다른 점은 두 가지뿐이다.
+ *  1. 링크가 아니다(설정 화면에서 이동시킬 이유가 없다).
+ *  2. `grid-rows-subgrid` 대신 `flex` — subgrid 는 목록 그리드 안에서만 의미가 있다.
+ */
 const OpenSettingsPreview = ({ settings }: OpenSettingsPreviewProps) => {
   const {
     title,
@@ -26,68 +37,88 @@ const OpenSettingsPreview = ({ settings }: OpenSettingsPreviewProps) => {
     careers,
   } = settings;
 
-  // 공개 카드는 **대표 경력만** 노출하고, 미지정이면 경력 줄 자체를 렌더하지 않는다.
+  // 공개 카드는 **대표 경력만** 노출하고, 미지정이면 배지 자체를 렌더하지 않는다.
   // 여기서 첫 경력으로 폴백하면 실제 노출과 달라져 미리보기가 거짓말을 하게 된다.
   const representativeCareer =
     careers.find((career) => career.isRepresentative) ?? null;
+  const badge = careerBadgeLabel(representativeCareer);
+
+  // 편집 중에는 빈 문자열이 들어오므로 null 로 정규화해 공개 카드와 같은 폴백을 태운다.
+  const cardTitle = title?.trim() ? title : null;
+  const displayNickname = nickname ?? '멘토';
   const price = getLowestPrice(durations);
 
   return (
     <section className="rounded-xl border border-gray-200 bg-white p-5 md:p-6">
       <h2 className="mb-4 text-base font-semibold text-gray-900">미리보기</h2>
 
-      <div className="overflow-hidden rounded-xl border border-gray-200">
-        {/* 프로필 이미지 영역 */}
-        <div className="relative flex h-40 items-center justify-center bg-gray-100">
-          {profileImage ? (
+      <div className="flex w-full flex-col gap-3 overflow-hidden">
+        {/* 썸네일 — 프로필 이미지가 있으면 흰 배경 위 이미지, 없으면 브랜드 컬러 배경 + 제목 텍스트 */}
+        <div
+          className={`md:rounded-xs relative aspect-[540/421] overflow-hidden rounded-sm ${
+            profileImage ? 'bg-white' : 'bg-primary'
+          }`}
+        >
+          {profileImage && (
             <img
               src={profileImage}
-              alt="프로필 미리보기"
-              className="h-full w-full object-cover"
+              alt={displayNickname}
+              className="absolute inset-0 h-full w-full object-cover"
             />
-          ) : (
-            <span className="text-sm text-gray-500">프로필 이미지</span>
           )}
-        </div>
 
-        {/* 메타 영역 */}
-        <div className="flex flex-col gap-2 p-4">
-          <p className="text-sm font-semibold text-gray-900">
-            {title || '타이틀을 입력해주세요'}
-          </p>
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="bg-primary-10 text-primary rounded px-2 py-0.5 text-xs font-medium">
-              {categories.map((c) => CATEGORY_LABELS[c]).join(' · ')}
+          {/* 대표 직무 배지 */}
+          {badge && (
+            <span className="rounded-xs bg-neutral-0/80 text-xxsmall10 text-static-100 md:text-xxsmall12 absolute left-2 top-2 px-2.5 py-1 font-semibold">
+              {badge}
             </span>
-            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-              {durations.map(durationLabel).join('·')}
-            </span>
-          </div>
-          <p className="text-xs text-gray-500">{nickname}</p>
-          {representativeCareer && (
-            <p className="text-xs text-gray-500">
-              {representativeCareerLabel(representativeCareer)}
-              {representativeCareer.startDate && (
-                <>
-                  {' '}
-                  (
-                  {formatCareerPeriod(
-                    representativeCareer.startDate,
-                    representativeCareer.endDate,
-                  )}
-                  )
-                </>
-              )}
+          )}
+
+          {!profileImage && (
+            <p
+              className={`text-small18 relative line-clamp-3 px-4 pb-4 font-bold text-white ${
+                badge ? 'pt-11' : 'pt-4'
+              }`}
+            >
+              {cardTitle ?? imagePlaceholderTitle(displayNickname)}
             </p>
           )}
-          <p className="text-xs text-gray-500">
-            피드백 {(feedbackStartDate ?? '').slice(5) || '미정'} ~{' '}
-            {(feedbackEndDate ?? '').slice(5) || '미정'}
-          </p>
-          <p className="text-primary text-sm font-semibold">
-            {durations.length > 1 ? '최저 ' : ''}
-            {formatPrice(price)}
-          </p>
+
+          {/* 진행시간 / 가격 바 — 썸네일 위에 겹쳐 카드 높이를 비율에 고정한다 */}
+          <div className="bg-neutral-0 text-xsmall14 absolute inset-x-0 bottom-0 flex items-center justify-between px-4 py-2.5 text-white">
+            <span>{durationsLabel(durations)}</span>
+            <span className="font-bold">
+              {cardPriceLabel(durations, price)}
+            </span>
+          </div>
+        </div>
+
+        <h3 className="text-1-semibold text-xsmall14 md:text-xsmall16 line-clamp-2">
+          {cardTitle ?? `${displayNickname}의 1:1 멘토링`}
+        </h3>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-1 tracking-[-0.4px] md:gap-1.5">
+            <span className="text-xxsmall12 text-neutral-0 font-normal">
+              진행기간
+            </span>
+            <span className="text-0.75-medium text-primary-dark">
+              {formatOpeningPeriod(feedbackStartDate, feedbackEndDate)}
+            </span>
+          </div>
+
+          {categories.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1.5">
+              {categories.map((category) => (
+                <div
+                  key={category}
+                  className="text-xxsmall12 border-neutral-95 bg-neutral-95 text-neutral-40 flex items-center justify-center rounded-[3px] border px-2 py-1 text-center font-normal"
+                >
+                  {CATEGORY_LABELS[category]}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/apps/mentor/src/pages/live-mentoring/open-status/OpenStatusPage.tsx
+++ b/apps/mentor/src/pages/live-mentoring/open-status/OpenStatusPage.tsx
@@ -12,8 +12,24 @@ const STATUS_CLASS: Record<OpenStatusRow['status'], string> = {
   CLOSED: 'bg-gray-100 text-gray-500',
 };
 
-const headerCellClass = 'px-4 py-3 text-left text-xs font-medium text-gray-500';
+// 헤더는 "피드백 기간"·"예약 수"처럼 공백이 있어 좁은 열에서 두 줄로 쪼개진다.
+const headerCellClass =
+  'whitespace-nowrap px-4 py-3 text-left text-xs font-medium text-gray-500';
 const bodyCellClass = 'px-4 py-3 text-sm text-gray-700';
+
+/**
+ * 통째로 하나의 값인 셀 — 절대 끊지 않는다.
+ * 기본 `word-break: normal` 은 **한글을 글자 단위로 끊어서**, 좁은 열에서
+ * "30분·6" / "0분" 이나 "07-14 ~" / "07-28" 같은 깨진 표기가 나온다.
+ */
+const atomicCellClass = `${bodyCellClass} whitespace-nowrap`;
+
+/**
+ * 길어질 수 있는 한글 텍스트 셀 — 줄바꿈은 허용하되 **어절 단위로만** 끊는다.
+ * `break-keep`(word-break: keep-all) 이 없으면 "자소서 실전 첨" / "삭 멘토링" 처럼
+ * 단어 중간에서 잘린다.
+ */
+const textCellClass = `${bodyCellClass} break-keep`;
 
 const OpenStatusPage = () => {
   const { data, isLoading } = useLiveMentoringOpenStatusQuery();
@@ -33,7 +49,11 @@ const OpenStatusPage = () => {
         </p>
       </header>
 
-      <div className="overflow-hidden rounded-xl border border-gray-200">
+      {/*
+        표가 `min-w-[560px]` 라 좁은 화면에서는 컨테이너를 넘친다.
+        `overflow-hidden` 이면 넘친 열이 잘린 채 접근할 방법이 없으므로 가로 스크롤을 준다.
+      */}
+      <div className="overflow-x-auto rounded-xl border border-gray-200">
         <table className="w-full min-w-[560px]">
           <thead className="border-b border-gray-200 bg-gray-50">
             <tr>
@@ -71,29 +91,28 @@ const OpenStatusPage = () => {
                   key={`${row.categories.join()}-${index}`}
                   className="border-b border-gray-100 last:border-b-0"
                 >
-                  <td className={bodyCellClass}>{row.title}</td>
-                  <td className={bodyCellClass}>
+                  <td className={textCellClass}>{row.title}</td>
+                  <td className={textCellClass}>
                     {row.categories.map((c) => CATEGORY_LABELS[c]).join(' · ')}
                   </td>
-                  <td className={bodyCellClass}>
+                  <td className={atomicCellClass}>
                     {row.durations.map(durationLabel).join('·')}
                   </td>
-                  <td className={bodyCellClass}>
-                    {row.feedbackStartDate.slice(5)} ~{' '}
-                    {row.feedbackEndDate.slice(5)}
+                  <td className={atomicCellClass}>
+                    {`${row.feedbackStartDate.slice(5)} ~ ${row.feedbackEndDate.slice(5)}`}
                   </td>
-                  <td className={bodyCellClass}>
+                  <td className={atomicCellClass}>
                     {row.durations.length > 1 ? '최저 ' : ''}
                     {formatPrice(row.price)}
                   </td>
                   <td className={bodyCellClass}>
                     <span
-                      className={`rounded px-2 py-0.5 text-xs font-medium ${STATUS_CLASS[row.status]}`}
+                      className={`whitespace-nowrap rounded px-2 py-0.5 text-xs font-medium ${STATUS_CLASS[row.status]}`}
                     >
                       {STATUS_LABEL[row.status]}
                     </span>
                   </td>
-                  <td className={bodyCellClass}>{row.reservationCount}건</td>
+                  <td className={atomicCellClass}>{row.reservationCount}건</td>
                 </tr>
               ))
             )}

--- a/apps/mentor/src/pages/live-mentoring/open-status/__tests__/OpenStatusPage.test.tsx
+++ b/apps/mentor/src/pages/live-mentoring/open-status/__tests__/OpenStatusPage.test.tsx
@@ -51,6 +51,16 @@ describe('OpenStatusPage', () => {
     expect(screen.getByText('7건')).toBeInTheDocument();
   });
 
+  // 이전에는 "{시작} ~" 와 "{종료}" 가 별도 텍스트 노드라 좁은 열에서 중간이 끊겼다.
+  // 한 덩어리로 렌더되는지(= 끊기지 않는지) 고정한다.
+  it('피드백 기간을 끊기지 않는 한 덩어리로 렌더한다', () => {
+    queryState = { data: rows, isLoading: false };
+    render(<OpenStatusPage />);
+
+    expect(screen.getByText('07-14 ~ 07-28')).toBeInTheDocument();
+    expect(screen.getByText('07-11 ~ 07-24')).toBeInTheDocument();
+  });
+
   it('상태 뱃지(오픈중/마감)를 노출한다', () => {
     queryState = { data: rows, isLoading: false };
     render(<OpenStatusPage />);

--- a/apps/mentor/src/pages/live-mentoring/ui/LiveMentoringOpenBadge.tsx
+++ b/apps/mentor/src/pages/live-mentoring/ui/LiveMentoringOpenBadge.tsx
@@ -1,0 +1,30 @@
+import { useLiveMentoringSettingsQuery } from '@/api/live-mentoring/liveMentoring';
+
+/**
+ * 사이드바 "1대1 라이브 멘토링" 그룹 라벨 옆에 붙는 오픈 상태 배지.
+ *
+ * 멘토가 오픈 설정 화면에 들어가지 않고도 지금 오픈 중인지 한눈에 알 수 있게 한다.
+ * 오픈 중이 아니거나 아직 불러오는 중이면 아무것도 렌더하지 않는다 —
+ * "마감" 같은 반대 상태까지 늘 띄우면 사이드바가 시끄러워지고, 정작 알아야 할
+ * "지금 열려 있다"는 신호가 묻힌다.
+ *
+ * 쿼리는 오픈 설정 화면과 **같은 쿼리 키**를 써서 캐시를 공유한다(중복 요청 없음).
+ *
+ * 별도 모듈인 이유: `MentorSidebar` 자체는 react-query 의존이 없어 테스트에서
+ * QueryClientProvider 없이 렌더된다. `NotificationBell` 과 같은 이유·같은 방식으로
+ * 분리해 사이드바 테스트에서 모킹할 수 있게 한다.
+ */
+const LiveMentoringOpenBadge = () => {
+  const { data } = useLiveMentoringSettingsQuery();
+
+  if (!data?.isOpen) return null;
+
+  return (
+    <span className="bg-primary-10 text-primary text-xxsmall12 flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-medium">
+      <span className="bg-primary h-1 w-1 rounded-full" aria-hidden="true" />
+      오픈중
+    </span>
+  );
+};
+
+export default LiveMentoringOpenBadge;

--- a/apps/mentor/src/pages/live-mentoring/ui/__tests__/LiveMentoringOpenBadge.test.tsx
+++ b/apps/mentor/src/pages/live-mentoring/ui/__tests__/LiveMentoringOpenBadge.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { LiveMentoringSettings } from '@/api/live-mentoring/liveMentoringSchema';
+
+let queryState: { data?: LiveMentoringSettings } = {};
+
+vi.mock('@/api/live-mentoring/liveMentoring', () => ({
+  useLiveMentoringSettingsQuery: () => queryState,
+}));
+
+import LiveMentoringOpenBadge from '../LiveMentoringOpenBadge';
+
+const settings = (isOpen: boolean) =>
+  ({ isOpen }) as unknown as LiveMentoringSettings;
+
+afterEach(() => {
+  queryState = {};
+});
+
+describe('LiveMentoringOpenBadge', () => {
+  it('오픈 중이면 오픈중 배지를 노출한다', () => {
+    queryState = { data: settings(true) };
+    render(<LiveMentoringOpenBadge />);
+    expect(screen.getByText('오픈중')).toBeInTheDocument();
+  });
+
+  it('오픈 중이 아니면 아무것도 렌더하지 않는다', () => {
+    queryState = { data: settings(false) };
+    const { container } = render(<LiveMentoringOpenBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('아직 불러오지 못했으면 아무것도 렌더하지 않는다', () => {
+    queryState = {};
+    const { container } = render(<LiveMentoringOpenBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
멘토 앱 1대1 라이브 멘토링 화면의 UI 문제 4건을 정리했습니다. 커밋은 화면 단위로 3개입니다.

---

## 1. 오픈 중 잠금 UI (`OpenSettingsPage`)

**기존 문제**

- 설정 영역에 `blur-[8px]`, 그 위 오버레이에 `backdrop-blur-sm` — **블러가 두 번** 걸려 내용을 전혀 읽을 수 없었습니다.
- 오픈 닫기 버튼이 같은 페이지의 다른 버튼과 스케일이 2배 넘게 어긋났습니다.

  | | 오픈 닫기 | 저장 / 오픈하기 |
  |---|---|---|
  | 패딩 | `px-20 py-6` | `px-10 py-2.5` |
  | 글자 | `text-2xl font-bold` | `text-sm font-medium` |
  | 모서리 | `rounded-2xl` | `rounded-lg` |

- `fixed inset-0 … lg:left-[296px]` 로 사이드바 폭을 하드코딩했습니다.
- `pointer-events-none` 은 마우스만 막습니다 — 블러 뒤 입력 필드에 **Tab 으로 포커스가 갔습니다.** `aria-hidden` 영역에 포커스가 들어가는 건 스크린리더에서 특히 나쁩니다.

**변경**

- 전체 화면 오버레이 제거 → 제목 아래 **인라인 상태 배너**(`role="status"`)
- `blur` 제거 → `<fieldset disabled>` 로 **입력만** 잠금 (키보드 포커스도 함께 차단)
- 버튼을 페이지 스케일에 맞추고, 되돌리는 동작이라 outline 으로

> **잠글 대상은 화면이 아니라 입력입니다.** 오픈 중 멘토가 가장 자주 하는 일은 "내가 어떤 조건으로 열었더라?" 확인인데, 기존 UI 는 그걸 통째로 가렸습니다.

## 2. 미리보기를 공개 카드와 동일하게 (`OpenSettingsPreview`)

기존 미리보기는 **공개 카드에 없는 정보를 보여주고 있었습니다** — 닉네임 줄, 회사명, 재직 기간. 멘토가 `네이버 · 기획 (2019.01 ~ 재직중)` 이 노출된다고 믿고 오픈했지만 실제 카드엔 직무 `기획` 만 뜹니다. 디자인 차이보다 이 **정보 불일치**가 더 큰 문제였습니다.

`apps/web/.../list/MentorCard.tsx` 를 그대로 재현했습니다 — 썸네일 `aspect-[540/421]`, 좌상단 직무 배지, 썸네일 위에 겹친 진행시간·가격 바, `진행기간 26.07.14 ~ 26.07.28`, 카테고리별 개별 태그.

앱 간 컴포넌트를 공유하지 않는 규칙 때문에 마크업·포맷터를 복제했고, **양쪽 주석에 원본 경로와 "같이 고쳐야 한다"** 를 남겼습니다.

## 3. 오픈 현황 표 줄바꿈 (`OpenStatusPage`)

브라우저 기본 `word-break: normal` 이 **한글을 글자 단위로** 끊어, 7열짜리 좁은 표에서 곳곳이 깨졌습니다.

| 열 | 깨지던 모습 |
|---|---|
| 피드백 기간 | `07-14 ~` / `07-28` (텍스트 노드도 분리돼 있었음) |
| 진행시간 | `30분·6` / `0분` |
| 타이틀 | `자소서 실전 첨` / `삭 멘토링` |
| 헤더 | `피드백` / `기간` |

- 원자값 셀은 `whitespace-nowrap`, 긴 한글 셀은 `break-keep`(어절 단위) 으로 구분
- 피드백 기간을 템플릿 문자열 하나로 합침
- **컨테이너를 `overflow-hidden` → `overflow-x-auto`** — `min-w-[560px]` 표가 좁은 화면에서 잘린 채 볼 방법이 없었고, `nowrap` 을 넣으면 더 넓어지므로 함께 고쳤습니다

## 4. 사이드바 오픈중 배지

```
1대1 라이브 멘토링  ● 오픈중          ⌄
```

오픈 설정 화면과 **같은 쿼리 키**를 써서 캐시를 공유합니다(중복 요청 없음, 오픈/닫기 시 함께 갱신).

- 오픈 중이 아니거나 로딩 중이면 아무것도 렌더하지 않습니다. "마감" 까지 늘 띄우면 사이드바가 시끄러워지고 정작 알아야 할 신호가 묻힙니다.
- `MentorSidebar` 는 react-query 의존이 없어 테스트에서 provider 없이 렌더됩니다. `NotificationBell` 과 같은 이유·같은 방식으로 배지를 별도 모듈로 분리했습니다.

---

## 검증

- mentor vitest **594개 전부 통과** (**신규 9개**)
- `tsc --noEmit` 무오류 / prettier 통과 / eslint error 0

신규 테스트가 각 설계 의도를 고정합니다:

```
✓ 오픈 중이면 상단에 오픈 중 상태 배너를 노출한다
✓ 오픈 중에는 설정 입력이 비활성화되지만 값은 그대로 읽을 수 있다   ← "가리지 말고 잠그기"
✓ 미리보기가 공개 카드와 같은 표기 규칙을 따른다
✓ 피드백 기간을 끊기지 않는 한 덩어리로 렌더한다                  ← 노드 분리 회귀 방지
✓ 오픈 중이 아니면 아무것도 렌더하지 않는다
```

## 리뷰 시 봐주실 점

**실화면 확인을 못 했습니다.** 멘토 로그인이 필요해 제 환경에서 재현하지 못했고, 검증은 테스트·타입체크까지입니다. `pnpm dev:mock:mentor` 로 띄워 오픈 설정 → 오픈하기 → 잠금 상태와 우측 미리보기를 직접 봐주세요.

## 이 PR 범위 밖 (판단 필요)

- **오픈 현황 날짜 포맷이 다른 화면과 다릅니다.** 여기는 `07-14 ~ 07-28`(하이픈, 연도 없음), 미리보기·웹 카드는 `26.07.14 ~ 26.07.28`(점, 연도 포함). 통일할지 결정 필요합니다.
- **정산 현황 표도 같은 구조**입니다(`overflow-hidden` + `min-w-[520px]` + 한글 셀). 같은 증상이 있을 텐데 요청 범위 밖이라 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)